### PR TITLE
Story 1.6: Onboarding — Branding Step

### DIFF
--- a/_bmad-output/implementation-artifacts/1-6-onboarding-branding-step.md
+++ b/_bmad-output/implementation-artifacts/1-6-onboarding-branding-step.md
@@ -164,11 +164,11 @@ so that the widget matches my brand.
 - [Source: src/app/routing/guard/onboarding.guard.ts — isNotOnboardedGuard / isOnboardedGuard flip]
 - [Source: e2e/fixtures/onboarding.fixture.ts — `onboardedUser` fixture pattern for a future seeded in-progress fixture]
 
-### ATDD Artifacts (planned)
+### ATDD Artifacts
 
-- Checklist: `_bmad-output/test-artifacts/atdd-checklist-1-6-onboarding-branding-step.md`
-- E2E tests: `e2e/tests/onboarding-branding.spec.ts`
-- Component tests: `src/app/onboarding/branding-page/branding-page.component.spec.ts`
+- Checklist: `_bmad-output/test-artifacts/atdd-checklist-1-6-onboarding-branding-step.md` (RED phase — 33 scaffolds)
+- E2E tests: `e2e/tests/onboarding-branding.spec.ts` (7 tests, all `test.skip`)
+- Component tests: `src/app/onboarding/branding-page/branding-page.component.spec.ts` (26 tests, all `it.skip`)
 
 ## Dev Agent Record
 

--- a/_bmad-output/implementation-artifacts/1-6-onboarding-branding-step.md
+++ b/_bmad-output/implementation-artifacts/1-6-onboarding-branding-step.md
@@ -1,0 +1,183 @@
+---
+baseline_commit: 7a7e6ff
+status: ready-for-dev
+---
+
+# Story 1.6: Onboarding — Branding Step
+
+Status: ready-for-dev
+
+## Story
+
+As a restaurant owner,
+I want to customize my widget colors and add a custom field,
+so that the widget matches my brand.
+
+## Acceptance Criteria
+
+**Given** the branding step
+**When** it loads
+**Then** a centered card shows "Step 3 of 3: Branding"
+**And** a "Skip" link is visible (this step is optional)
+
+**Given** the branding step
+**When** the owner configures colors
+**Then** a hex color picker is shown for primary color
+**And** a hex color picker is shown for secondary color
+**And** sensible defaults are pre-filled
+
+**Given** the branding step
+**When** the owner configures a custom field
+**Then** inputs are shown for: label (text), required (toggle), enabled (toggle)
+**And** the custom field defaults to disabled
+
+**Given** the branding step
+**When** the owner clicks "Skip"
+**Then** the onboarding is completed without saving branding changes
+**And** the owner can configure these later in Settings
+
+**Given** the branding step
+**When** the owner clicks "Complete"
+**Then** the branding data is saved to the restaurant profile
+**And** onboarding is marked as complete
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Create Branding Page Component (AC: 1, 2, 3, 5)
+  - [ ] Subtask 1.1: Create `src/app/onboarding/branding-page/branding-page.component.ts`
+  - [ ] Subtask 1.2: Implement step indicator ("Step 3 of 3: Branding")
+  - [ ] Subtask 1.3: Implement heading "Style your booking widget"
+  - [ ] Subtask 1.4: Implement "Skip" link (optional-step affordance, link-style button), disabled while saving
+  - [ ] Subtask 1.5: Implement primary color picker (hex text input + native color swatch)
+  - [ ] Subtask 1.6: Implement secondary color picker (hex text input + native color swatch)
+  - [ ] Subtask 1.7: Pre-fill sensible defaults from existing `restaurant.whiteLabel` (fallback to DESIGN palette `#1A1A1A` / `#8FA67A`)
+  - [ ] Subtask 1.8: Implement hex validation (`^#[0-9a-fA-F]{6}$`) with error message; block "Complete" when invalid
+  - [ ] Subtask 1.9: Implement custom field: label (text input), required (toggle), enabled (toggle), defaulting to disabled
+  - [ ] Subtask 1.10: Implement "Complete" button (filled, full-width) with loading state, error handling, disabled state + `aria-busy` during save
+  - [ ] Subtask 1.11: Style per DESIGN.md: centered card, max-width 480px, warm linen background
+
+- [ ] Task 2: Update Onboarding Service (AC: 2, 5)
+  - [ ] Subtask 2.1: Update `createRestaurant` whiteLabel defaults from `#000000`/`#FFFFFF` to the DESIGN.md platform palette (`#1A1A1A` primary / `#8FA67A` secondary)
+  - [ ] Subtask 2.2: Reuse `updateRestaurant` for branding data — no new service methods required
+
+- [ ] Task 3: Update Angular Routing (AC: 5)
+  - [ ] Subtask 3.1: Add `/onboarding/branding` route to `app.routes.ts` (lazy `loadComponent`, guards `[isAuthenticatedGuard, isNotOnboardedGuard]`)
+  - [ ] Subtask 3.2: Verify Step 2 "Continue" navigates to `/onboarding/branding` (already implemented in Story 1.5 — no change expected)
+
+- [ ] Task 4: Write Unit Tests (AC: 1, 2, 3, 4, 5)
+  - [ ] Subtask 4.1: Test BrandingPageComponent — step indicator renders
+  - [ ] Subtask 4.2: Test BrandingPageComponent — "Skip" link visible
+  - [ ] Subtask 4.3: Test BrandingPageComponent — color pickers pre-filled from restaurant doc (or DESIGN defaults)
+  - [ ] Subtask 4.4: Test BrandingPageComponent — invalid hex blocks "Complete"
+  - [ ] Subtask 4.5: Test BrandingPageComponent — custom field defaults to disabled
+  - [ ] Subtask 4.6: Test BrandingPageComponent — "Complete" saves `{ whiteLabel, customField, onboardingCompleted: true }` (customField persisted even when `enabled: false`) and navigates to `/dashboard`
+  - [ ] Subtask 4.7: Test BrandingPageComponent — "Skip" saves only `onboardingCompleted: true` and navigates to `/dashboard`
+  - [ ] Subtask 4.8: Test OnboardingService — `createRestaurant` uses DESIGN palette defaults
+
+- [ ] Task 5: E2E / ATDD Coverage (deferred to AT phase via `bmad-testarch-atdd`)
+  - [ ] Subtask 5.1: Generate red-phase checklist `_bmad-output/test-artifacts/atdd-checklist-1-6-onboarding-branding-step.md`
+  - [ ] Subtask 5.2: E2E tests: extend `e2e/tests/onboarding-wizard.spec.ts` (drive the fresh `onboardingPage` fixture through steps 1→3) or add `e2e/tests/onboarding-branding.spec.ts`; cover full complete flow and skip flow
+  - [ ] Subtask 5.3: Consider a seeded "in-progress" restaurant fixture (hours/tableGroups set, `onboardingCompleted: false`) to land directly on Step 3
+
+## Dev Notes
+
+### Architecture Patterns & Constraints
+
+**AD-2 — Direct Firebase from Browser:**
+- Onboarding service calls Firestore directly. No API layer.
+- Security rules already enforce owner-based access (Story 1.2).
+
+**AD-13 — One Restaurant per Account:**
+- Single restaurant per auth account. `getRestaurantByOwner` returns the first match (fine — one per account).
+
+**Completion guard flip (FR-40):**
+- After `onboardingCompleted: true` is saved, `isNotOnboardedGuard` redirects away from `/onboarding` and `isOnboardedGuard` permits `/dashboard`.
+- Complete and Skip both navigate to `['/dashboard']` after saving.
+- The Deploy/embed-code page (FR-41) is Story 1.7 — out of scope here.
+
+### Code patterns established (from Story 1.1–1.5)
+
+- **Component shape:** signal-based, `inject()` for dependencies, standalone (implicit), route-loaded via `loadComponent` (no selector needed).
+- **Page chrome:** `<div class="h-screen flex items-center justify-center bg-[#FAF7F2]">` wrapping `mat-card appearance="outlined"` `relative w-full max-w-[480px] mx-4 p-6`; `mat-progress-bar mode="indeterminate"` with `aria-label="Loading"` while `loading()`; step caption `<p class="text-sm text-gray-500 mb-1">` + `<h1 class="text-2xl font-semibold">`.
+- **State:** `loading = signal(false)`, `error = signal<string | null>(null)`, derived state via `computed()`, data pre-fill in `ngOnInit` via `getRestaurantByOwner(user.uid)`.
+- **Forms:** `FormsModule` + `[(ngModel)]`/`ngModelChange` to stay consistent with the availability step (AGENTS.md prefers Signal Forms for *new* forms; this page follows the established Step 2 pattern — see Deferred Work).
+- **Submission:** save via `updateRestaurant(restaurantId, data)`, then `router.navigate(...)`; `aria-busy` + disabled CTA while saving; errors in `role="alert"` `<div class="text-red-700 text-sm">`.
+- **Selectors:** `data-testid` attributes on interactive elements for E2E.
+- **Firebase access:** `import { getFirebaseDb, getFirebaseAuth } from '../../shared/firebase-config'`.
+
+### Files to create
+
+- `src/app/onboarding/branding-page/branding-page.component.ts` — Branding page component
+- `src/app/onboarding/branding-page/branding-page.component.html` — Template
+- `src/app/onboarding/branding-page/branding-page.component.scss` — Styles (kept empty; Tailwind utilities inline)
+- `src/app/onboarding/branding-page/branding-page.component.spec.ts` — Tests
+
+### Files to modify
+
+- `src/app/services/onboarding.service.ts` — Change `createRestaurant` whiteLabel defaults to `#1A1A1A` / `#8FA67A` (Subtask 2.1)
+- `src/app/app.routes.ts` — Add `/onboarding/branding` route (Subtask 3.1)
+
+### Testing requirements
+
+- Unit tests for BrandingPageComponent (mock OnboardingService via `ng-mocks`).
+- Never call real Firestore in tests — mock (`vi.mock('firebase/auth')`, `vi.mock('firebase/firestore')`, `vi.mock('firebase/app')`).
+- If `effect()` is used, Angular effects are async — tests need `vi.advanceTimersByTime()` + `fixture.whenStable()`.
+- Navigation assertions: compare `UrlTree` with `.toString()` when guards return `parseUrl()`.
+- Accessibility: native `<input type="color">` has no text content — every color input needs an `aria-label`. Errors must be announced (`role="alert"`); avoid pure black/white widget colors in dark mode (DESIGN.md:103).
+- E2E work is deferred to the AT phase (Task 5).
+
+### Previous Story Learnings
+
+**From Story 1.5 (Availability Step):**
+- Reuse `updateRestaurant(restaurantId, data)` — its signature `Partial<Omit<Restaurant, 'id' | 'slug' | 'ownerId'>>` already accepts `whiteLabel`, `customField`, and `onboardingCompleted`. No new service methods needed.
+- Step 2 "Continue" already navigates to `['/onboarding/branding']` — only the route registration is missing.
+- E2E location lesson: Story 1.5 planned a standalone availability spec under `tests/e2e/`, but it was never created — availability coverage lives folded into `e2e/tests/onboarding-wizard.spec.ts`. For 1.6, plan E2E under `e2e/tests/` (extend the wizard spec or add `onboarding-branding.spec.ts`), not a legacy `tests/e2e/` path.
+- `getRestaurantByOwner` returns the first of multiple (fine — AD-13 one restaurant per account).
+- Validation messages: `computed()` returning a message string + `role="alert"` div + disabled CTA.
+- Native color input always returns `#rrggbb`; validate the hex text input and keep both controls in sync.
+
+**Story 1.6-specific decisions (confirmed):**
+- Heading is **"Style your booking widget"**.
+- Sensible defaults: pre-fill from existing `restaurant.whiteLabel` (guaranteed non-null — `createRestaurant` always sets it); fall back to the DESIGN.md platform palette only for legacy/missing docs. `createRestaurant` defaults change to `#1A1A1A` (Ink) primary / `#8FA67A` (Sage) secondary.
+- Required/enabled toggles use `MatSlideToggle` (design language: "toggle"). `MatCheckbox` remains available for consistency if preferred.
+- Skip must NOT write `whiteLabel`/`customField` — save only `{ onboardingCompleted: true }`.
+- Complete persists **exactly** `{ whiteLabel, customField, onboardingCompleted: true }`. `customField` is saved as configured even when `enabled: false` — the widget (Epic 2) respects the flag per FR-38/AD-8.
+- **No new dependencies:** the color picker uses the native `<input type="color">` plus existing Angular Material (`MatSlideToggle`, `MatCard`, `MatButton`, `MatInput`, `MatFormField`, `MatProgressBar`) — do not add a third-party color-picker package.
+
+### Project Structure Notes
+
+- Standalone components live under `src/app/onboarding/<page>-page/` with colocated `*.spec.ts`.
+- No NgModules; routes lazy-load components via `loadComponent`.
+- `WhiteLabel { primaryColor, secondaryColor }` and `CustomField { label, required, enabled }` types already exist and are optional `customField?` on `Restaurant` — no type changes required.
+
+### References
+
+- [Source: epics.md — Story 1.6 (Onboarding — Branding Step), lines 392-427]
+- [Source: ARCHITECTURE-SPINE.md — AD-8 (custom field optional with restaurant-defined label, lines 78-80); Data Model (Firestore) `whiteLabel`/`customField` fields, lines 160-198]
+- [Source: PRD — FR-37 White-Label Colors, FR-38 Custom Field, FR-39 Skip Optional Steps, FR-40 Onboarding Completion (lines 404-436); FR-41 Embed Code Page (line 437, out of scope)]
+- [Source: EXPERIENCE.md — Step 3 table (line 55); onboarding card + skip link (line 91); Step 3 walkthrough (line 172)]
+- [Source: DESIGN.md — palette Ink `#1A1A1A` / Sage `#8FA67A` (lines 8-17); avoid pure black/white in dark mode (line 103); onboarding card (line 150); color picker = hex input + native color swatch (line 151)]
+- [Source: src/shared/types/restaurant.ts — WhiteLabel, CustomField]
+- [Source: src/app/services/onboarding.service.ts — createRestaurant, updateRestaurant, getRestaurantByOwner]
+- [Source: src/app/onboarding/availability-page/availability-page.component.{ts,html} — Step 2 pattern to mirror]
+- [Source: src/app/app.routes.ts — route registration pattern (`onboarding/availability`)]
+- [Source: src/app/routing/guard/onboarding.guard.ts — isNotOnboardedGuard / isOnboardedGuard flip]
+- [Source: e2e/fixtures/onboarding.fixture.ts — `onboardedUser` fixture pattern for a future seeded in-progress fixture]
+
+### ATDD Artifacts (planned)
+
+- Checklist: `_bmad-output/test-artifacts/atdd-checklist-1-6-onboarding-branding-step.md`
+- E2E tests: `e2e/tests/onboarding-branding.spec.ts`
+- Component tests: `src/app/onboarding/branding-page/branding-page.component.spec.ts`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List
+
+### Review Findings

--- a/_bmad-output/implementation-artifacts/1-6-onboarding-branding-step.md
+++ b/_bmad-output/implementation-artifacts/1-6-onboarding-branding-step.md
@@ -1,11 +1,11 @@
 ---
 baseline_commit: 7a7e6ff
-status: ready-for-dev
+status: done
 ---
 
 # Story 1.6: Onboarding — Branding Step
 
-Status: ready-for-dev
+Status: done
 
 ## Story
 
@@ -43,41 +43,41 @@ so that the widget matches my brand.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create Branding Page Component (AC: 1, 2, 3, 5)
-  - [ ] Subtask 1.1: Create `src/app/onboarding/branding-page/branding-page.component.ts`
-  - [ ] Subtask 1.2: Implement step indicator ("Step 3 of 3: Branding")
-  - [ ] Subtask 1.3: Implement heading "Style your booking widget"
-  - [ ] Subtask 1.4: Implement "Skip" link (optional-step affordance, link-style button), disabled while saving
-  - [ ] Subtask 1.5: Implement primary color picker (hex text input + native color swatch)
-  - [ ] Subtask 1.6: Implement secondary color picker (hex text input + native color swatch)
-  - [ ] Subtask 1.7: Pre-fill sensible defaults from existing `restaurant.whiteLabel` (fallback to DESIGN palette `#1A1A1A` / `#8FA67A`)
-  - [ ] Subtask 1.8: Implement hex validation (`^#[0-9a-fA-F]{6}$`) with error message; block "Complete" when invalid
-  - [ ] Subtask 1.9: Implement custom field: label (text input), required (toggle), enabled (toggle), defaulting to disabled
-  - [ ] Subtask 1.10: Implement "Complete" button (filled, full-width) with loading state, error handling, disabled state + `aria-busy` during save
-  - [ ] Subtask 1.11: Style per DESIGN.md: centered card, max-width 480px, warm linen background
+- [x] Task 1: Create Branding Page Component (AC: 1, 2, 3, 5)
+  - [x] Subtask 1.1: Create `src/app/onboarding/branding-page/branding-page.component.ts`
+  - [x] Subtask 1.2: Implement step indicator ("Step 3 of 3: Branding")
+  - [x] Subtask 1.3: Implement heading "Style your booking widget"
+  - [x] Subtask 1.4: Implement "Skip" link (optional-step affordance, link-style button), disabled while saving
+  - [x] Subtask 1.5: Implement primary color picker (hex text input + native color swatch)
+  - [x] Subtask 1.6: Implement secondary color picker (hex text input + native color swatch)
+  - [x] Subtask 1.7: Pre-fill sensible defaults from existing `restaurant.whiteLabel` (fallback to DESIGN palette `#1A1A1A` / `#8FA67A`)
+  - [x] Subtask 1.8: Implement hex validation (`^#[0-9a-fA-F]{6}$`) with error message; block "Complete" when invalid
+  - [x] Subtask 1.9: Implement custom field: label (text input), required (toggle), enabled (toggle), defaulting to disabled
+  - [x] Subtask 1.10: Implement "Complete" button (filled, full-width) with loading state, error handling, disabled state + `aria-busy` during save
+  - [x] Subtask 1.11: Style per DESIGN.md: centered card, max-width 480px, warm linen background
 
-- [ ] Task 2: Update Onboarding Service (AC: 2, 5)
-  - [ ] Subtask 2.1: Update `createRestaurant` whiteLabel defaults from `#000000`/`#FFFFFF` to the DESIGN.md platform palette (`#1A1A1A` primary / `#8FA67A` secondary)
-  - [ ] Subtask 2.2: Reuse `updateRestaurant` for branding data — no new service methods required
+- [x] Task 2: Update Onboarding Service (AC: 2, 5)
+  - [x] Subtask 2.1: Update `createRestaurant` whiteLabel defaults from `#000000`/`#FFFFFF` to the DESIGN.md platform palette (`#1A1A1A` primary / `#8FA67A` secondary)
+  - [x] Subtask 2.2: Reuse `updateRestaurant` for branding data — no new service methods required
 
-- [ ] Task 3: Update Angular Routing (AC: 5)
-  - [ ] Subtask 3.1: Add `/onboarding/branding` route to `app.routes.ts` (lazy `loadComponent`, guards `[isAuthenticatedGuard, isNotOnboardedGuard]`)
-  - [ ] Subtask 3.2: Verify Step 2 "Continue" navigates to `/onboarding/branding` (already implemented in Story 1.5 — no change expected)
+- [x] Task 3: Update Angular Routing (AC: 5)
+  - [x] Subtask 3.1: Add `/onboarding/branding` route to `app.routes.ts` (lazy `loadComponent`, guards `[isAuthenticatedGuard, isNotOnboardedGuard]`)
+  - [x] Subtask 3.2: Verify Step 2 "Continue" navigates to `/onboarding/branding` (already implemented in Story 1.5 — no change expected)
 
-- [ ] Task 4: Write Unit Tests (AC: 1, 2, 3, 4, 5)
-  - [ ] Subtask 4.1: Test BrandingPageComponent — step indicator renders
-  - [ ] Subtask 4.2: Test BrandingPageComponent — "Skip" link visible
-  - [ ] Subtask 4.3: Test BrandingPageComponent — color pickers pre-filled from restaurant doc (or DESIGN defaults)
-  - [ ] Subtask 4.4: Test BrandingPageComponent — invalid hex blocks "Complete"
-  - [ ] Subtask 4.5: Test BrandingPageComponent — custom field defaults to disabled
-  - [ ] Subtask 4.6: Test BrandingPageComponent — "Complete" saves `{ whiteLabel, customField, onboardingCompleted: true }` (customField persisted even when `enabled: false`) and navigates to `/dashboard`
-  - [ ] Subtask 4.7: Test BrandingPageComponent — "Skip" saves only `onboardingCompleted: true` and navigates to `/dashboard`
-  - [ ] Subtask 4.8: Test OnboardingService — `createRestaurant` uses DESIGN palette defaults
+- [x] Task 4: Write Unit Tests (AC: 1, 2, 3, 4, 5)
+  - [x] Subtask 4.1: Test BrandingPageComponent — step indicator renders
+  - [x] Subtask 4.2: Test BrandingPageComponent — "Skip" link visible
+  - [x] Subtask 4.3: Test BrandingPageComponent — color pickers pre-filled from restaurant doc (or DESIGN defaults)
+  - [x] Subtask 4.4: Test BrandingPageComponent — invalid hex blocks "Complete"
+  - [x] Subtask 4.5: Test BrandingPageComponent — custom field defaults to disabled
+  - [x] Subtask 4.6: Test BrandingPageComponent — "Complete" saves `{ whiteLabel, customField, onboardingCompleted: true }` (customField persisted even when `enabled: false`) and navigates to `/dashboard`
+  - [x] Subtask 4.7: Test BrandingPageComponent — "Skip" saves only `onboardingCompleted: true` and navigates to `/dashboard`
+  - [x] Subtask 4.8: Test OnboardingService — `createRestaurant` uses DESIGN palette defaults
 
-- [ ] Task 5: E2E / ATDD Coverage (deferred to AT phase via `bmad-testarch-atdd`)
-  - [ ] Subtask 5.1: Generate red-phase checklist `_bmad-output/test-artifacts/atdd-checklist-1-6-onboarding-branding-step.md`
-  - [ ] Subtask 5.2: E2E tests: extend `e2e/tests/onboarding-wizard.spec.ts` (drive the fresh `onboardingPage` fixture through steps 1→3) or add `e2e/tests/onboarding-branding.spec.ts`; cover full complete flow and skip flow
-  - [ ] Subtask 5.3: Consider a seeded "in-progress" restaurant fixture (hours/tableGroups set, `onboardingCompleted: false`) to land directly on Step 3
+- [x] Task 5: E2E / ATDD Coverage (deferred to AT phase via `bmad-testarch-atdd`)
+  - [x] Subtask 5.1: Generate red-phase checklist `_bmad-output/test-artifacts/atdd-checklist-1-6-onboarding-branding-step.md`
+  - [x] Subtask 5.2: E2E tests: extend `e2e/tests/onboarding-wizard.spec.ts` (drive the fresh `onboardingPage` fixture through steps 1→3) or add `e2e/tests/onboarding-branding.spec.ts`; cover full complete flow and skip flow
+  - [x] Subtask 5.3: Consider a seeded "in-progress" restaurant fixture (hours/tableGroups set, `onboardingCompleted: false`) to land directly on Step 3
 
 ## Dev Notes
 
@@ -167,17 +167,45 @@ so that the widget matches my brand.
 ### ATDD Artifacts
 
 - Checklist: `_bmad-output/test-artifacts/atdd-checklist-1-6-onboarding-branding-step.md` (RED phase — 33 scaffolds)
-- E2E tests: `e2e/tests/onboarding-branding.spec.ts` (7 tests, all `test.skip`)
-- Component tests: `src/app/onboarding/branding-page/branding-page.component.spec.ts` (26 tests, all `it.skip`)
+- E2E tests: `e2e/tests/onboarding-branding.spec.ts` (7 tests, all activated and passing)
+- Component tests: `src/app/onboarding/branding-page/branding-page.component.spec.ts` (26 tests, all activated and passing)
 
 ## Dev Agent Record
 
 ### Agent Model Used
 
+- opencode / big-pickle (CLI agent session)
+
 ### Debug Log References
+
+- `/tmp/ngtest5.log`, `/tmp/ngtest6.log` — full `npx ng test --watch=false` runs (142/142 passed)
+- `/tmp/pw-branding.log`, `/tmp/pw-branding2.log`, `/tmp/pw-branding3.log` — E2E branding runs (final: 7/7 passed)
+- `/tmp/pw-full.log`, `/tmp/pw-full2.log`, `/tmp/pw-full3.log` — full E2E suite runs (28/29; 1 pre-existing flake in `e2e/fixtures/onboarding.fixture.ts` auth `waitForURL`, see Completion Notes)
+- `/tmp/pw-wizard.log`, `/tmp/pw-wizard2.log` — onboarding-wizard spec alone (8/8 passed)
+- `/tmp/lint.log` — `ng lint` clean
+- `/tmp/build.log` — `ng build` success (pre-existing initial-bundle budget warning, unrelated)
 
 ### Completion Notes List
 
+- Implemented the full branding step (Step 3 of 3): heading "Style your booking widget", "Skip" link, primary/secondary hex color pickers with native swatches, custom field (label + required/enabled checkboxes), "Complete" button with loading/error states.
+- Complete persists exactly `{ whiteLabel, customField, onboardingCompleted: true }` and navigates to `['/dashboard']`; Skip persists only `{ onboardingCompleted: true }` and navigates to `['/dashboard']`.
+- `createRestaurant` whiteLabel defaults changed to DESIGN palette `#1A1A1A` / `#8FA67A`.
+- Added `/onboarding/branding` route (lazy `loadComponent`, `[isAuthenticatedGuard, isNotOnboardedGuard]`); Step 2 "Continue" already navigated to it.
+- Unit tests: 142/142 green. Root cause of the 7 initially-red tests: `beforeEach` lacked `await fixture.whenStable()`; `ngOnInit`'s async `getRestaurantByOwner` resolved after the initial `detectChanges()`, leaving DOM stale. The 2 re-mock tests also re-triggered `ngOnInit` on a consumed fixture — fixed by recreating `fixture`/`component` inside those tests. Custom-field ngModel needs 2 `whenStable` cycles.
+- E2E: 7/7 green. Root causes of red tests: (a) `data-testid` on the `mat-slide-toggle`/`mat-checkbox` host doesn't expose a checkable role and host clicks don't toggle — switched to `mat-checkbox` and role-based selectors (`getByRole('checkbox', { name: 'Required' })`), matching the availability step; (b) form controls were not disabled during the async prefill, so rapid user input could be clobbered by `ngOnInit`'s prefill — fixed by `[disabled]="loading()"` on all inputs (Playwright auto-waits for enabled, eliminating the race; also correct UX).
+- Pre-existing full-suite flake (NOT caused by this story): `e2e/fixtures/onboarding.fixture.ts:57` `page.waitForURL(/\/(onboarding|dashboard)/)` times out after auth signup on a random test when the whole suite runs (28/29). Same fixture hits each run's failure; the branding and wizard specs each pass standalone. Left untouched (out of scope).
+
 ### File List
 
+- `src/app/onboarding/branding-page/branding-page.component.ts` — new component
+- `src/app/onboarding/branding-page/branding-page.component.html` — new template (hex inputs + swatches, custom field, alerts, Complete/Skip)
+- `src/app/onboarding/branding-page/branding-page.component.scss` — new (empty; Tailwind utilities inline)
+- `src/app/onboarding/branding-page/branding-page.component.spec.ts` — 26 activated tests
+- `src/app/services/onboarding.service.ts` — whiteLabel defaults → `#1A1A1A` / `#8FA67A`
+- `src/app/app.routes.ts` — `/onboarding/branding` route
+- `e2e/tests/onboarding-branding.spec.ts` — 7 activated tests (role-based checkbox selectors)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` — 1-6 → done
+
 ### Review Findings
+
+- Not yet reviewed — story marked `done` per `workflow.on_complete` customization. Recommended follow-up: run `code-review` with a different LLM.

--- a/_bmad-output/implementation-artifacts/1-6-onboarding-branding-step.md
+++ b/_bmad-output/implementation-artifacts/1-6-onboarding-branding-step.md
@@ -208,4 +208,9 @@ so that the widget matches my brand.
 
 ### Review Findings
 
-- Not yet reviewed — story marked `done` per `workflow.on_complete` customization. Recommended follow-up: run `code-review` with a different LLM.
+- [x] [Review][Patch] Silent prefill failure can wipe existing saved branding on Complete (catch swallows read errors; Complete overwrites with defaults) [src/app/onboarding/branding-page/branding-page.component.ts:73]
+- [x] [Review][Patch] `loading()` conflates prefill and save — "Saving..." label and disabled state shown during initial prefill [src/app/onboarding/branding-page/branding-page.component.ts:33]
+- [x] [Review][Patch] `getRestaurantId()` re-queries Firestore on every submit (extra read + TOCTOU window) instead of reusing the prefill fetch [src/app/onboarding/branding-page/branding-page.component.ts:152]
+- [x] [Review][Patch] Partial `whiteLabel`/`customField` sub-fields flow unvalidated into the persisted payload (`set(undefined)` sticks hex error + swatch desync) [src/app/onboarding/branding-page/branding-page.component.ts:63]
+- [x] [Review][Patch] Raw SDK error messages surface verbatim in `role=alert`; prefill failures swallowed silently [src/app/onboarding/branding-page/branding-page.component.ts:122]
+- [x] [Review][Patch] Skip link stays keyboard-focusable/activatable while "disabled" (pointer-events + aria-disabled only) [src/app/onboarding/branding-page/branding-page.component.html:12]

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-07-14
-# last_updated: 2026-07-31
+# last_updated: 2026-08-02
 # project: osefdetalife
 # project_key: NOKEY
 # tracking_system: file-system
@@ -41,7 +41,7 @@
 # - Retrospective appends its action items to action_items; sprint-status surfaces open ones
 
 generated: 2026-07-14
-last_updated: 2026-07-31
+last_updated: 2026-08-02
 project: osefdetalife
 project_key: NOKEY
 tracking_system: file-system

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-07-14
-# last_updated: 2026-07-14
+# last_updated: 2026-07-31
 # project: osefdetalife
 # project_key: NOKEY
 # tracking_system: file-system
@@ -41,7 +41,7 @@
 # - Retrospective appends its action items to action_items; sprint-status surfaces open ones
 
 generated: 2026-07-14
-last_updated: 2026-07-21
+last_updated: 2026-07-31
 project: osefdetalife
 project_key: NOKEY
 tracking_system: file-system
@@ -55,7 +55,7 @@ development_status:
   1-3-user-authentication: done
   1-4-onboarding-basics-step: done
   1-5-onboarding-availability-step: done
-  1-6-onboarding-branding-step: backlog
+  1-6-onboarding-branding-step: ready-for-dev
   1-7-onboarding-completion-deploy: backlog
   epic-1-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -55,7 +55,7 @@ development_status:
   1-3-user-authentication: done
   1-4-onboarding-basics-step: done
   1-5-onboarding-availability-step: done
-  1-6-onboarding-branding-step: ready-for-dev
+  1-6-onboarding-branding-step: done
   1-7-onboarding-completion-deploy: backlog
   epic-1-retrospective: optional
 

--- a/_bmad-output/test-artifacts/atdd-checklist-1-6-onboarding-branding-step.md
+++ b/_bmad-output/test-artifacts/atdd-checklist-1-6-onboarding-branding-step.md
@@ -1,0 +1,76 @@
+---
+stepsCompleted: ['step-01-preflight-and-context', 'step-02-generation-mode', 'step-03-test-strategy', 'step-04-generate-tests', 'step-04c-aggregate', 'step-05-validate-and-complete']
+lastStep: 'step-05-validate-and-complete'
+lastSaved: '2026-07-31'
+storyId: '1.6'
+storyKey: '1-6-onboarding-branding-step'
+storyFile: '_bmad-output/implementation-artifacts/1-6-onboarding-branding-step.md'
+atddChecklistPath: '_bmad-output/test-artifacts/atdd-checklist-1-6-onboarding-branding-step.md'
+generatedTestFiles: ['e2e/tests/onboarding-branding.spec.ts', 'src/app/onboarding/branding-page/branding-page.component.spec.ts']
+---
+
+# ATDD Checklist: Story 1.6 — Onboarding — Branding Step
+
+## TDD Red Phase (Current)
+
+✅ Red-phase test scaffolds generated
+
+- E2E Tests: 7 tests (all skipped)
+- Component Tests: 26 tests (all skipped)
+
+## Acceptance Criteria Coverage
+
+| AC | Description | E2E | Component |
+|----|-------------|-----|-----------|
+| 1 | Step indicator, heading, and Skip link | ✅ | ✅ |
+| 2 | Color pickers with sensible defaults and hex validation | ✅ | ✅ |
+| 3 | Custom field controls defaulting to disabled | ✅ | ✅ |
+| 4 | Skip completes onboarding without saving branding | ✅ | ✅ |
+| 5 | Complete saves branding data and navigates to dashboard | ✅ | ✅ |
+
+## Next Steps (Task-by-Task Activation)
+
+During implementation of each task:
+
+1. Remove `test.skip()` from the current test file or scenario
+2. Run tests: `npx vitest run` (component) or `npx playwright test` (E2E)
+3. Verify the activated test fails first, then passes after implementation (green phase)
+4. If any activated tests still fail unexpectedly:
+   - Either fix implementation (feature bug)
+   - Or fix test (test bug)
+5. Commit passing tests
+
+## Implementation Guidance
+
+**Component to implement:**
+- `src/app/onboarding/branding-page/branding-page.component.ts`
+- `src/app/onboarding/branding-page/branding-page.component.html`
+- `src/app/onboarding/branding-page/branding-page.component.scss`
+
+**Service default changes:**
+- `OnboardingService.createRestaurant`: whiteLabel defaults → `#1A1A1A` / `#8FA67A` (DESIGN palette)
+
+**Routes to add:**
+- `/onboarding/branding` in `app.routes.ts`
+
+**Navigation to update:**
+- `availability-page.component.ts`: Step 2 continue navigates to `/onboarding/branding`
+
+**Existing E2E to keep green:**
+- `e2e/tests/onboarding-wizard.spec.ts` (steps 1→2; update only if it asserted the old `/onboarding` redirect after step 2)
+
+## Generated Test Files
+
+### E2E Tests
+- `e2e/tests/onboarding-branding.spec.ts` — 7 tests (4 P0, 2 P1, 1 P2) covering all acceptance criteria; uses the fresh `onboardingPage` fixture driven through steps 1→2, Firestore persistence check via `db` fixture
+
+### Component Tests
+- `src/app/onboarding/branding-page/branding-page.component.spec.ts` — 26 tests (12 P0, 11 P1, 3 P2) covering all acceptance criteria; spies on `OnboardingService` (`updateRestaurant`, `getRestaurant`, `getCurrentUser`, `getRestaurantByOwner`) with `provideRouter`
+
+## Knowledge Fragments Used
+
+- component-tdd.md
+- test-quality.md
+- selector-resilience.md
+- data-factories.md
+- fixture-architecture.md

--- a/e2e/tests/onboarding-branding.spec.ts
+++ b/e2e/tests/onboarding-branding.spec.ts
@@ -33,7 +33,7 @@ async function getRestaurantBySlug(db: Firestore, slug: string) {
 }
 
 test.describe('Onboarding Branding Step', () => {
-  test.skip('[P0] step 3 loads with step indicator, heading and skip link', async ({ onboardingPage }) => {
+  test('[P0] step 3 loads with step indicator, heading and skip link', async ({ onboardingPage }) => {
     await completeStepsOneAndTwo(onboardingPage, 'branding-loads-test');
 
     await expect(onboardingPage.getByText('Step 3 of 3: Branding')).toBeVisible();
@@ -44,7 +44,7 @@ test.describe('Onboarding Branding Step', () => {
     await expect(skipLink).toHaveAccessibleName('Skip');
   });
 
-  test.skip('[P0] color pickers are pre-filled with sensible defaults', async ({ onboardingPage }) => {
+  test('[P0] color pickers are pre-filled with sensible defaults', async ({ onboardingPage }) => {
     await completeStepsOneAndTwo(onboardingPage, 'branding-defaults-test');
 
     const primarySwatch = onboardingPage.getByTestId('color-primary');
@@ -61,7 +61,7 @@ test.describe('Onboarding Branding Step', () => {
     await expect(secondarySwatch).toHaveValue(DEFAULT_SECONDARY.toLowerCase());
   });
 
-  test.skip('[P0] complete flow saves branding data and marks onboarding complete', async ({ onboardingPage, db }) => {
+  test('[P0] complete flow saves branding data and marks onboarding complete', async ({ onboardingPage, db }) => {
     const slug = 'branding-complete-test';
     await completeStepsOneAndTwo(onboardingPage, slug);
 
@@ -69,7 +69,7 @@ test.describe('Onboarding Branding Step', () => {
     await onboardingPage.getByTestId('hex-secondary').fill('#ABCDEF');
 
     await onboardingPage.getByTestId('custom-field-label').fill('Party size');
-    await onboardingPage.getByTestId('custom-field-required').click();
+    await onboardingPage.getByRole('checkbox', { name: 'Required' }).check();
 
     await onboardingPage.getByRole('button', { name: 'Complete' }).click();
     await onboardingPage.waitForURL(/dashboard/);
@@ -81,7 +81,7 @@ test.describe('Onboarding Branding Step', () => {
     expect(restaurant.customField).toEqual({ label: 'Party size', required: true, enabled: false });
   });
 
-  test.skip('[P0] skip flow completes onboarding without saving branding changes', async ({ onboardingPage, db }) => {
+  test('[P0] skip flow completes onboarding without saving branding changes', async ({ onboardingPage, db }) => {
     const slug = 'branding-skip-test';
     await completeStepsOneAndTwo(onboardingPage, slug);
 
@@ -95,15 +95,15 @@ test.describe('Onboarding Branding Step', () => {
     expect(restaurant.whiteLabel).toEqual({ primaryColor: DEFAULT_PRIMARY, secondaryColor: DEFAULT_SECONDARY });
   });
 
-  test.skip('[P1] custom field defaults to disabled with required off', async ({ onboardingPage }) => {
+  test('[P1] custom field defaults to disabled with required off', async ({ onboardingPage }) => {
     await completeStepsOneAndTwo(onboardingPage, 'branding-customfield-defaults-test');
 
     await expect(onboardingPage.getByTestId('custom-field-label')).toBeVisible();
-    await expect(onboardingPage.getByTestId('custom-field-required')).not.toBeChecked();
-    await expect(onboardingPage.getByTestId('custom-field-enabled')).not.toBeChecked();
+    await expect(onboardingPage.getByRole('checkbox', { name: 'Required' })).not.toBeChecked();
+    await expect(onboardingPage.getByRole('checkbox', { name: 'Enabled' })).not.toBeChecked();
   });
 
-  test.skip('[P1] invalid hex shows an error and disables complete', async ({ onboardingPage }) => {
+  test('[P1] invalid hex shows an error and disables complete', async ({ onboardingPage }) => {
     await completeStepsOneAndTwo(onboardingPage, 'branding-invalid-hex-test');
 
     await onboardingPage.getByTestId('hex-primary').fill('#GGGGGG');
@@ -115,7 +115,7 @@ test.describe('Onboarding Branding Step', () => {
     await expect(onboardingPage.getByRole('button', { name: 'Complete' })).toBeDisabled();
   });
 
-  test.skip('[P2] hex text input and color swatch stay in sync', async ({ onboardingPage }) => {
+  test('[P2] hex text input and color swatch stay in sync', async ({ onboardingPage }) => {
     await completeStepsOneAndTwo(onboardingPage, 'branding-sync-test');
 
     await onboardingPage.getByTestId('hex-primary').fill('#345678');

--- a/e2e/tests/onboarding-branding.spec.ts
+++ b/e2e/tests/onboarding-branding.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '../fixtures';
+import type { Page } from '@playwright/test';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import type { Firestore } from 'firebase/firestore';
+
+const DEFAULT_PRIMARY = '#1A1A1A';
+const DEFAULT_SECONDARY = '#8FA67A';
+
+async function completeStepsOneAndTwo(page: Page, slug: string): Promise<void> {
+  await page.getByRole('textbox', { name: /restaurant name/i }).fill('Branding Test Restaurant');
+
+  const slugInput = page.getByRole('textbox', { name: /slug/i });
+  await slugInput.fill(slug);
+
+  await expect(page.getByText('Slug is available').first()).toBeVisible({ timeout: 10_000 });
+
+  const continueButton = page.getByRole('button', { name: /continue/i });
+  await continueButton.click();
+
+  await page.getByRole('checkbox', { name: /toggle monday/i }).check();
+  await page.getByTestId('add-table-group').click();
+
+  const stepTwoContinue = page.getByRole('button', { name: /continue/i });
+  await expect(stepTwoContinue).toBeEnabled({ timeout: 10_000 });
+  await stepTwoContinue.click();
+}
+
+async function getRestaurantBySlug(db: Firestore, slug: string) {
+  const snapshot = await getDocs(query(collection(db, 'restaurants'), where('slug', '==', slug)));
+  if (snapshot.empty) throw new Error(`Restaurant with slug "${slug}" not found in Firestore`);
+  const doc = snapshot.docs[0];
+  return { id: doc.id, ...doc.data() };
+}
+
+test.describe('Onboarding Branding Step', () => {
+  test.skip('[P0] step 3 loads with step indicator, heading and skip link', async ({ onboardingPage }) => {
+    await completeStepsOneAndTwo(onboardingPage, 'branding-loads-test');
+
+    await expect(onboardingPage.getByText('Step 3 of 3: Branding')).toBeVisible();
+    await expect(onboardingPage.getByRole('heading', { name: 'Style your booking widget' })).toBeVisible();
+
+    const skipLink = onboardingPage.getByTestId('skip-link');
+    await expect(skipLink).toBeVisible();
+    await expect(skipLink).toHaveAccessibleName('Skip');
+  });
+
+  test.skip('[P0] color pickers are pre-filled with sensible defaults', async ({ onboardingPage }) => {
+    await completeStepsOneAndTwo(onboardingPage, 'branding-defaults-test');
+
+    const primarySwatch = onboardingPage.getByTestId('color-primary');
+    const secondarySwatch = onboardingPage.getByTestId('color-secondary');
+
+    await expect(primarySwatch).toBeVisible();
+    await expect(secondarySwatch).toBeVisible();
+    await expect(primarySwatch).toHaveAccessibleName('Primary color');
+    await expect(secondarySwatch).toHaveAccessibleName('Secondary color');
+
+    await expect(onboardingPage.getByTestId('hex-primary')).toHaveValue(DEFAULT_PRIMARY);
+    await expect(onboardingPage.getByTestId('hex-secondary')).toHaveValue(DEFAULT_SECONDARY);
+    await expect(primarySwatch).toHaveValue(DEFAULT_PRIMARY.toLowerCase());
+    await expect(secondarySwatch).toHaveValue(DEFAULT_SECONDARY.toLowerCase());
+  });
+
+  test.skip('[P0] complete flow saves branding data and marks onboarding complete', async ({ onboardingPage, db }) => {
+    const slug = 'branding-complete-test';
+    await completeStepsOneAndTwo(onboardingPage, slug);
+
+    await onboardingPage.getByTestId('hex-primary').fill('#123456');
+    await onboardingPage.getByTestId('hex-secondary').fill('#ABCDEF');
+
+    await onboardingPage.getByTestId('custom-field-label').fill('Party size');
+    await onboardingPage.getByTestId('custom-field-required').click();
+
+    await onboardingPage.getByRole('button', { name: 'Complete' }).click();
+    await onboardingPage.waitForURL(/dashboard/);
+    await expect(onboardingPage).toHaveURL(/dashboard/);
+
+    const restaurant = await getRestaurantBySlug(db, slug);
+    expect(restaurant.onboardingCompleted).toBe(true);
+    expect(restaurant.whiteLabel).toEqual({ primaryColor: '#123456', secondaryColor: '#ABCDEF' });
+    expect(restaurant.customField).toEqual({ label: 'Party size', required: true, enabled: false });
+  });
+
+  test.skip('[P0] skip flow completes onboarding without saving branding changes', async ({ onboardingPage, db }) => {
+    const slug = 'branding-skip-test';
+    await completeStepsOneAndTwo(onboardingPage, slug);
+
+    await onboardingPage.getByTestId('skip-link').click();
+    await onboardingPage.waitForURL(/dashboard/);
+    await expect(onboardingPage).toHaveURL(/dashboard/);
+
+    const restaurant = await getRestaurantBySlug(db, slug);
+    expect(restaurant.onboardingCompleted).toBe(true);
+    expect(restaurant.customField).toBeUndefined();
+    expect(restaurant.whiteLabel).toEqual({ primaryColor: DEFAULT_PRIMARY, secondaryColor: DEFAULT_SECONDARY });
+  });
+
+  test.skip('[P1] custom field defaults to disabled with required off', async ({ onboardingPage }) => {
+    await completeStepsOneAndTwo(onboardingPage, 'branding-customfield-defaults-test');
+
+    await expect(onboardingPage.getByTestId('custom-field-label')).toBeVisible();
+    await expect(onboardingPage.getByTestId('custom-field-required')).not.toBeChecked();
+    await expect(onboardingPage.getByTestId('custom-field-enabled')).not.toBeChecked();
+  });
+
+  test.skip('[P1] invalid hex shows an error and disables complete', async ({ onboardingPage }) => {
+    await completeStepsOneAndTwo(onboardingPage, 'branding-invalid-hex-test');
+
+    await onboardingPage.getByTestId('hex-primary').fill('#GGGGGG');
+
+    const alert = onboardingPage.getByRole('alert');
+    await expect(alert).toBeVisible();
+    await expect(alert).toContainText(/invalid|hex|color format/i);
+
+    await expect(onboardingPage.getByRole('button', { name: 'Complete' })).toBeDisabled();
+  });
+
+  test.skip('[P2] hex text input and color swatch stay in sync', async ({ onboardingPage }) => {
+    await completeStepsOneAndTwo(onboardingPage, 'branding-sync-test');
+
+    await onboardingPage.getByTestId('hex-primary').fill('#345678');
+
+    await expect(onboardingPage.getByTestId('hex-primary')).toHaveValue('#345678');
+    await expect(onboardingPage.getByTestId('color-primary')).toHaveValue('#345678');
+  });
+});

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -52,6 +52,14 @@ export const routes: Routes = [
     canActivate: [isAuthenticatedGuard, isNotOnboardedGuard],
   },
   {
+    path: 'onboarding/branding',
+    loadComponent: () =>
+      import('./onboarding/branding-page/branding-page.component').then(
+        (m) => m.BrandingPageComponent,
+      ),
+    canActivate: [isAuthenticatedGuard, isNotOnboardedGuard],
+  },
+  {
     path: '',
     redirectTo: 'dashboard',
     pathMatch: 'full',

--- a/src/app/onboarding/branding-page/branding-page.component.html
+++ b/src/app/onboarding/branding-page/branding-page.component.html
@@ -1,0 +1,146 @@
+<div class="h-screen flex items-center justify-center bg-[#FAF7F2]">
+  <mat-card appearance="outlined" class="relative w-full max-w-[480px] mx-4 p-6">
+    @if (loading()) {
+      <mat-progress-bar mode="indeterminate" class="absolute top-0 left-0 right-0" aria-label="Loading" />
+    }
+
+    <div class="mb-6 flex items-start justify-between gap-4">
+      <div>
+        <p class="text-sm text-gray-500 mb-1">Step 3 of 3: Branding</p>
+        <h1 class="text-2xl font-semibold">Style your booking widget</h1>
+      </div>
+      <a
+        href="#"
+        data-testid="skip-link"
+        class="text-sm text-gray-500 underline hover:text-gray-700"
+        [class.pointer-events-none]="loading()"
+        [attr.aria-disabled]="loading() || null"
+        (click)="skipOnboarding($event)"
+      >
+        Skip
+      </a>
+    </div>
+
+    <div class="flex flex-col gap-4">
+      <section>
+        <h2 class="text-lg font-medium mb-3">Colors</h2>
+        <div class="flex flex-col gap-3">
+          <div class="flex items-center gap-3">
+            <mat-form-field appearance="outline" class="flex-1">
+              <mat-label>Primary color</mat-label>
+              <input
+                matInput
+                type="text"
+                [ngModel]="primaryColor()"
+                (ngModelChange)="onPrimaryHexChange($event)"
+                name="hex-primary"
+                data-testid="hex-primary"
+                aria-label="Primary color hex value"
+                placeholder="#1A1A1A"
+                [disabled]="loading()"
+              />
+            </mat-form-field>
+            <input
+              type="color"
+              [value]="primaryColor()"
+              (input)="onPrimarySwatchChange(primarySwatch.value)"
+              #primarySwatch
+              data-testid="color-primary"
+              aria-label="Primary color"
+              [disabled]="loading()"
+              class="h-11 w-14 shrink-0 rounded border border-gray-300 bg-white p-1"
+            />
+          </div>
+
+          <div class="flex items-center gap-3">
+            <mat-form-field appearance="outline" class="flex-1">
+              <mat-label>Secondary color</mat-label>
+              <input
+                matInput
+                type="text"
+                [ngModel]="secondaryColor()"
+                (ngModelChange)="onSecondaryHexChange($event)"
+                name="hex-secondary"
+                data-testid="hex-secondary"
+                aria-label="Secondary color hex value"
+                placeholder="#8FA67A"
+                [disabled]="loading()"
+              />
+            </mat-form-field>
+            <input
+              type="color"
+              [value]="secondaryColor()"
+              (input)="onSecondarySwatchChange(secondarySwatch.value)"
+              #secondarySwatch
+              data-testid="color-secondary"
+              aria-label="Secondary color"
+              [disabled]="loading()"
+              class="h-11 w-14 shrink-0 rounded border border-gray-300 bg-white p-1"
+            />
+          </div>
+        </div>
+      </section>
+
+      @if (hexError()) {
+        <div role="alert" class="text-red-700 text-sm">{{ hexError() }}</div>
+      }
+
+      <section class="border-t pt-4 mt-2">
+        <h2 class="text-lg font-medium mb-3">Custom field</h2>
+        <div class="flex flex-col gap-3">
+          <mat-form-field appearance="outline">
+            <mat-label>Custom field label</mat-label>
+            <input
+              matInput
+              type="text"
+              [ngModel]="customFieldLabel()"
+              (ngModelChange)="onCustomFieldLabelChange($event)"
+              name="custom-field-label"
+              data-testid="custom-field-label"
+              placeholder="e.g. Dietary notes"
+              [disabled]="loading()"
+            />
+          </mat-form-field>
+
+          <mat-checkbox
+            [checked]="customFieldRequired()"
+            (change)="customFieldRequired.set($event.checked)"
+            [disabled]="loading()"
+            data-testid="custom-field-required"
+          >
+            Required
+          </mat-checkbox>
+
+          <mat-checkbox
+            [checked]="customFieldEnabled()"
+            (change)="customFieldEnabled.set($event.checked)"
+            [disabled]="loading()"
+            data-testid="custom-field-enabled"
+          >
+            Enabled
+          </mat-checkbox>
+        </div>
+      </section>
+
+      @if (error()) {
+        <div role="alert" class="text-red-700 text-sm">{{ error() }}</div>
+      }
+
+      <button
+        matButton="filled"
+        type="button"
+        [disabled]="!canComplete()"
+        [attr.aria-busy]="loading() || null"
+        data-testid="complete-button"
+        (click)="completeOnboarding()"
+        class="w-full"
+      >
+        @if (loading()) {
+          Saving...
+        } @else {
+          Complete
+        }
+      </button>
+    </div>
+  </mat-card>
+</div>

--- a/src/app/onboarding/branding-page/branding-page.component.html
+++ b/src/app/onboarding/branding-page/branding-page.component.html
@@ -1,6 +1,6 @@
 <div class="h-screen flex items-center justify-center bg-[#FAF7F2]">
   <mat-card appearance="outlined" class="relative w-full max-w-[480px] mx-4 p-6">
-    @if (loading()) {
+    @if (busy()) {
       <mat-progress-bar mode="indeterminate" class="absolute top-0 left-0 right-0" aria-label="Loading" />
     }
 
@@ -13,8 +13,9 @@
         href="#"
         data-testid="skip-link"
         class="text-sm text-gray-500 underline hover:text-gray-700"
-        [class.pointer-events-none]="loading()"
-        [attr.aria-disabled]="loading() || null"
+        [class.pointer-events-none]="busy()"
+        [attr.aria-disabled]="busy() || null"
+        [attr.tabindex]="busy() ? -1 : null"
         (click)="skipOnboarding($event)"
       >
         Skip
@@ -37,7 +38,7 @@
                 data-testid="hex-primary"
                 aria-label="Primary color hex value"
                 placeholder="#1A1A1A"
-                [disabled]="loading()"
+                [disabled]="busy()"
               />
             </mat-form-field>
             <input
@@ -47,7 +48,7 @@
               #primarySwatch
               data-testid="color-primary"
               aria-label="Primary color"
-              [disabled]="loading()"
+              [disabled]="busy()"
               class="h-11 w-14 shrink-0 rounded border border-gray-300 bg-white p-1"
             />
           </div>
@@ -64,7 +65,7 @@
                 data-testid="hex-secondary"
                 aria-label="Secondary color hex value"
                 placeholder="#8FA67A"
-                [disabled]="loading()"
+                [disabled]="busy()"
               />
             </mat-form-field>
             <input
@@ -74,7 +75,7 @@
               #secondarySwatch
               data-testid="color-secondary"
               aria-label="Secondary color"
-              [disabled]="loading()"
+              [disabled]="busy()"
               class="h-11 w-14 shrink-0 rounded border border-gray-300 bg-white p-1"
             />
           </div>
@@ -98,14 +99,14 @@
               name="custom-field-label"
               data-testid="custom-field-label"
               placeholder="e.g. Dietary notes"
-              [disabled]="loading()"
+              [disabled]="busy()"
             />
           </mat-form-field>
 
           <mat-checkbox
             [checked]="customFieldRequired()"
             (change)="customFieldRequired.set($event.checked)"
-            [disabled]="loading()"
+            [disabled]="busy()"
             data-testid="custom-field-required"
           >
             Required
@@ -114,7 +115,7 @@
           <mat-checkbox
             [checked]="customFieldEnabled()"
             (change)="customFieldEnabled.set($event.checked)"
-            [disabled]="loading()"
+            [disabled]="busy()"
             data-testid="custom-field-enabled"
           >
             Enabled
@@ -130,12 +131,12 @@
         matButton="filled"
         type="button"
         [disabled]="!canComplete()"
-        [attr.aria-busy]="loading() || null"
+        [attr.aria-busy]="busy() || null"
         data-testid="complete-button"
         (click)="completeOnboarding()"
         class="w-full"
       >
-        @if (loading()) {
+        @if (saving()) {
           Saving...
         } @else {
           Complete

--- a/src/app/onboarding/branding-page/branding-page.component.spec.ts
+++ b/src/app/onboarding/branding-page/branding-page.component.spec.ts
@@ -1,0 +1,324 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { BrandingPageComponent } from './branding-page.component';
+import { OnboardingService } from '../../services/onboarding.service';
+import type { Restaurant } from '../../../shared/types/restaurant';
+
+const RESTAURANT_FIXTURE: Restaurant = {
+  id: 'test-id',
+  name: 'Test Restaurant',
+  slug: 'test-restaurant',
+  ownerId: 'user-1',
+  timezone: 'Europe/London',
+  hours: {},
+  tableGroups: [],
+  whiteLabel: { primaryColor: '#C0392B', secondaryColor: '#27AE60' },
+  onboardingCompleted: false,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+const BRANDED_RESTAURANT_FIXTURE: Restaurant = {
+  ...RESTAURANT_FIXTURE,
+  whiteLabel: { primaryColor: '#1A1A1A', secondaryColor: '#8FA67A' },
+  customField: { label: 'Dietary notes', required: true, enabled: true },
+};
+
+describe('BrandingPageComponent', () => {
+  let component: BrandingPageComponent;
+  let fixture: ComponentFixture<BrandingPageComponent>;
+  let router: Router;
+  let onboardingServiceSpy: {
+    updateRestaurant: ReturnType<typeof vi.fn>;
+    getRestaurant: ReturnType<typeof vi.fn>;
+    getCurrentUser: ReturnType<typeof vi.fn>;
+    getRestaurantByOwner: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    onboardingServiceSpy = {
+      updateRestaurant: vi.fn().mockResolvedValue(undefined),
+      getRestaurant: vi.fn().mockResolvedValue(RESTAURANT_FIXTURE),
+      getCurrentUser: vi.fn().mockReturnValue({ uid: 'user-1' }),
+      getRestaurantByOwner: vi.fn().mockResolvedValue(RESTAURANT_FIXTURE),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [BrandingPageComponent],
+      providers: [
+        provideRouter([{ path: 'dashboard', component: BrandingPageComponent }]),
+        { provide: OnboardingService, useValue: onboardingServiceSpy },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    fixture = TestBed.createComponent(BrandingPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('Step Indicator (AC: 1)', () => {
+    it.skip('[P0] should display step 3 of 3 caption', () => {
+      const stepIndicator = fixture.nativeElement.querySelector('p');
+      expect(stepIndicator?.textContent).toContain('Step 3 of 3: Branding');
+    });
+
+    it.skip('[P0] should display the "Style your booking widget" heading', () => {
+      const heading = fixture.nativeElement.querySelector('h1');
+      expect(heading?.textContent).toContain('Style your booking widget');
+    });
+
+    it.skip('[P1] should show a visible Skip link', () => {
+      const skipLink = fixture.nativeElement.querySelector('[data-testid="skip-link"]');
+      expect(skipLink).toBeTruthy();
+      expect(skipLink?.textContent).toContain('Skip');
+    });
+  });
+
+  describe('Color Pickers (AC: 2)', () => {
+    it.skip('[P0] should show primary and secondary color pickers', () => {
+      expect(fixture.nativeElement.querySelector('[data-testid="color-primary"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('[data-testid="color-secondary"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('[data-testid="hex-primary"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('[data-testid="hex-secondary"]')).toBeTruthy();
+    });
+
+    it.skip('[P0] should pre-fill colors from restaurant.whiteLabel', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component.primaryColor()).toBe('#C0392B');
+      expect(component.secondaryColor()).toBe('#27AE60');
+      expect(fixture.nativeElement.querySelector('[data-testid="hex-primary"]')?.value).toBe('#C0392B');
+      expect(fixture.nativeElement.querySelector('[data-testid="hex-secondary"]')?.value).toBe('#27AE60');
+    });
+
+    it.skip('[P1] should fall back to DESIGN palette when whiteLabel is missing', async () => {
+      onboardingServiceSpy.getRestaurantByOwner.mockResolvedValue({
+        ...RESTAURANT_FIXTURE,
+        whiteLabel: undefined,
+      } as unknown as Restaurant);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component.primaryColor()).toBe('#1A1A1A');
+      expect(component.secondaryColor()).toBe('#8FA67A');
+      expect(fixture.nativeElement.querySelector('[data-testid="hex-primary"]')?.value).toBe('#1A1A1A');
+      expect(fixture.nativeElement.querySelector('[data-testid="hex-secondary"]')?.value).toBe('#8FA67A');
+    });
+
+    it.skip('[P1] should keep the hex text input and color swatch in sync', () => {
+      const hexInput = fixture.nativeElement.querySelector('[data-testid="hex-primary"]');
+      hexInput.value = '#00ff88';
+      hexInput.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(component.primaryColor()).toBe('#00ff88');
+      expect(fixture.nativeElement.querySelector('[data-testid="color-primary"]')?.value).toBe('#00ff88');
+    });
+
+    it.skip('[P2] should expose aria-labels on the native color inputs', () => {
+      expect(fixture.nativeElement.querySelector('[data-testid="color-primary"]')?.getAttribute('aria-label')).toBe('Primary color');
+      expect(fixture.nativeElement.querySelector('[data-testid="color-secondary"]')?.getAttribute('aria-label')).toBe('Secondary color');
+    });
+  });
+
+  describe('Hex Validation (AC: 2)', () => {
+    it.skip('[P0] should show an error message for an invalid hex color', () => {
+      component.primaryColor.set('red');
+      fixture.detectChanges();
+
+      const alert = fixture.nativeElement.querySelector('[role="alert"]');
+      expect(alert).toBeTruthy();
+      expect(alert?.textContent.toLowerCase()).toContain('hex');
+    });
+
+    it.skip('[P0] should disable Complete while hex colors are invalid', () => {
+      component.primaryColor.set('12345');
+      fixture.detectChanges();
+
+      const completeButton = fixture.nativeElement.querySelector('[data-testid="complete-button"]');
+      expect(completeButton?.disabled).toBe(true);
+    });
+
+    it.skip('[P1] should accept valid hex colors case-insensitively', () => {
+      component.primaryColor.set('#aAbBcC');
+      component.secondaryColor.set('#AaBbCc');
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[role="alert"]')).toBeFalsy();
+      expect(fixture.nativeElement.querySelector('[data-testid="complete-button"]')?.disabled).toBe(false);
+    });
+
+    it.skip('[P2] should announce validation errors via role="alert"', () => {
+      component.primaryColor.set('not-a-color');
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[role="alert"]')).toBeTruthy();
+    });
+  });
+
+  describe('Custom Field (AC: 3)', () => {
+    it.skip('[P0] should render label, required, and enabled controls', () => {
+      expect(fixture.nativeElement.querySelector('[data-testid="custom-field-label"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('[data-testid="custom-field-required"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('[data-testid="custom-field-enabled"]')).toBeTruthy();
+    });
+
+    it.skip('[P0] should default the custom field to disabled', () => {
+      expect(component.customFieldLabel()).toBe('');
+      expect(component.customFieldRequired()).toBe(false);
+      expect(component.customFieldEnabled()).toBe(false);
+    });
+
+    it.skip('[P1] should pre-fill the custom field from restaurant.customField', async () => {
+      onboardingServiceSpy.getRestaurantByOwner.mockResolvedValue(BRANDED_RESTAURANT_FIXTURE);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component.customFieldLabel()).toBe('Dietary notes');
+      expect(component.customFieldRequired()).toBe(true);
+      expect(component.customFieldEnabled()).toBe(true);
+      expect(fixture.nativeElement.querySelector('[data-testid="custom-field-label"]')?.value).toBe('Dietary notes');
+    });
+
+    it.skip('[P1] should update customFieldLabel when the label input changes', () => {
+      const labelInput = fixture.nativeElement.querySelector('[data-testid="custom-field-label"]');
+      labelInput.value = 'Allergies';
+      labelInput.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(component.customFieldLabel()).toBe('Allergies');
+    });
+
+    it.skip('[P2] should update customFieldRequired from the required toggle', () => {
+      component.customFieldRequired.set(true);
+      fixture.detectChanges();
+
+      expect(component.customFieldRequired()).toBe(true);
+      expect(component.customFieldEnabled()).toBe(false);
+    });
+  });
+
+  describe('Skip (AC: 4)', () => {
+    it.skip('[P0] should save only { onboardingCompleted: true } on Skip', async () => {
+      vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      component.primaryColor.set('#FF0000');
+      fixture.detectChanges();
+
+      fixture.nativeElement.querySelector('[data-testid="skip-link"]')?.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(onboardingServiceSpy.updateRestaurant).toHaveBeenCalledTimes(1);
+      expect(onboardingServiceSpy.updateRestaurant).toHaveBeenCalledWith('test-id', {
+        onboardingCompleted: true,
+      });
+    });
+
+    it.skip('[P0] should not save whiteLabel or customField on Skip', async () => {
+      vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      fixture.nativeElement.querySelector('[data-testid="skip-link"]')?.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const payload = onboardingServiceSpy.updateRestaurant.mock.calls[0]?.[1];
+      expect(payload).not.toHaveProperty('whiteLabel');
+      expect(payload).not.toHaveProperty('customField');
+    });
+
+    it.skip('[P1] should navigate to /dashboard on Skip', async () => {
+      const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      fixture.nativeElement.querySelector('[data-testid="skip-link"]')?.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(navigateSpy).toHaveBeenCalledWith(['/dashboard']);
+    });
+  });
+
+  describe('Complete (AC: 5)', () => {
+    it.skip('[P0] should save whiteLabel, customField, and onboardingCompleted: true', async () => {
+      vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      component.primaryColor.set('#336699');
+      component.secondaryColor.set('#AABBCC');
+      component.customFieldLabel.set('Dietary notes');
+      component.customFieldRequired.set(true);
+      component.customFieldEnabled.set(true);
+      fixture.detectChanges();
+
+      fixture.nativeElement.querySelector('[data-testid="complete-button"]')?.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(onboardingServiceSpy.updateRestaurant).toHaveBeenCalledWith('test-id', {
+        whiteLabel: { primaryColor: '#336699', secondaryColor: '#AABBCC' },
+        customField: { label: 'Dietary notes', required: true, enabled: true },
+        onboardingCompleted: true,
+      });
+    });
+
+    it.skip('[P0] should persist customField even when the custom field is disabled', async () => {
+      vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      fixture.nativeElement.querySelector('[data-testid="complete-button"]')?.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(onboardingServiceSpy.updateRestaurant).toHaveBeenCalledWith('test-id', {
+        whiteLabel: { primaryColor: '#C0392B', secondaryColor: '#27AE60' },
+        customField: { label: '', required: false, enabled: false },
+        onboardingCompleted: true,
+      });
+    });
+
+    it.skip('[P1] should navigate to /dashboard on Complete', async () => {
+      const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      fixture.nativeElement.querySelector('[data-testid="complete-button"]')?.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(navigateSpy).toHaveBeenCalledWith(['/dashboard']);
+    });
+
+    it.skip('[P1] should disable Complete with aria-busy while saving', async () => {
+      vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      const completeButton = fixture.nativeElement.querySelector('[data-testid="complete-button"]');
+      completeButton?.click();
+      fixture.detectChanges();
+
+      expect(completeButton?.getAttribute('aria-busy')).toBe('true');
+      expect(completeButton?.disabled).toBe(true);
+
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    it.skip('[P1] should show the save error and not navigate when the update fails', async () => {
+      const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      onboardingServiceSpy.updateRestaurant.mockRejectedValueOnce(new Error('Save failed'));
+
+      fixture.nativeElement.querySelector('[data-testid="complete-button"]')?.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[role="alert"]')?.textContent).toContain('Save failed');
+      expect(navigateSpy).not.toHaveBeenCalled();
+    });
+
+    it.skip('[P1] should enable Complete when colors are valid', () => {
+      const completeButton = fixture.nativeElement.querySelector('[data-testid="complete-button"]');
+      expect(completeButton?.disabled).toBe(false);
+    });
+  });
+});

--- a/src/app/onboarding/branding-page/branding-page.component.spec.ts
+++ b/src/app/onboarding/branding-page/branding-page.component.spec.ts
@@ -54,20 +54,22 @@ describe('BrandingPageComponent', () => {
     fixture = TestBed.createComponent(BrandingPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
   });
 
   describe('Step Indicator (AC: 1)', () => {
-    it.skip('[P0] should display step 3 of 3 caption', () => {
+    it('[P0] should display step 3 of 3 caption', () => {
       const stepIndicator = fixture.nativeElement.querySelector('p');
       expect(stepIndicator?.textContent).toContain('Step 3 of 3: Branding');
     });
 
-    it.skip('[P0] should display the "Style your booking widget" heading', () => {
+    it('[P0] should display the "Style your booking widget" heading', () => {
       const heading = fixture.nativeElement.querySelector('h1');
       expect(heading?.textContent).toContain('Style your booking widget');
     });
 
-    it.skip('[P1] should show a visible Skip link', () => {
+    it('[P1] should show a visible Skip link', () => {
       const skipLink = fixture.nativeElement.querySelector('[data-testid="skip-link"]');
       expect(skipLink).toBeTruthy();
       expect(skipLink?.textContent).toContain('Skip');
@@ -75,14 +77,14 @@ describe('BrandingPageComponent', () => {
   });
 
   describe('Color Pickers (AC: 2)', () => {
-    it.skip('[P0] should show primary and secondary color pickers', () => {
+    it('[P0] should show primary and secondary color pickers', () => {
       expect(fixture.nativeElement.querySelector('[data-testid="color-primary"]')).toBeTruthy();
       expect(fixture.nativeElement.querySelector('[data-testid="color-secondary"]')).toBeTruthy();
       expect(fixture.nativeElement.querySelector('[data-testid="hex-primary"]')).toBeTruthy();
       expect(fixture.nativeElement.querySelector('[data-testid="hex-secondary"]')).toBeTruthy();
     });
 
-    it.skip('[P0] should pre-fill colors from restaurant.whiteLabel', async () => {
+    it('[P0] should pre-fill colors from restaurant.whiteLabel', async () => {
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
@@ -93,12 +95,14 @@ describe('BrandingPageComponent', () => {
       expect(fixture.nativeElement.querySelector('[data-testid="hex-secondary"]')?.value).toBe('#27AE60');
     });
 
-    it.skip('[P1] should fall back to DESIGN palette when whiteLabel is missing', async () => {
+    it('[P1] should fall back to DESIGN palette when whiteLabel is missing', async () => {
       onboardingServiceSpy.getRestaurantByOwner.mockResolvedValue({
         ...RESTAURANT_FIXTURE,
         whiteLabel: undefined,
       } as unknown as Restaurant);
 
+      fixture = TestBed.createComponent(BrandingPageComponent);
+      component = fixture.componentInstance;
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
@@ -109,7 +113,7 @@ describe('BrandingPageComponent', () => {
       expect(fixture.nativeElement.querySelector('[data-testid="hex-secondary"]')?.value).toBe('#8FA67A');
     });
 
-    it.skip('[P1] should keep the hex text input and color swatch in sync', () => {
+    it('[P1] should keep the hex text input and color swatch in sync', () => {
       const hexInput = fixture.nativeElement.querySelector('[data-testid="hex-primary"]');
       hexInput.value = '#00ff88';
       hexInput.dispatchEvent(new Event('input'));
@@ -119,14 +123,14 @@ describe('BrandingPageComponent', () => {
       expect(fixture.nativeElement.querySelector('[data-testid="color-primary"]')?.value).toBe('#00ff88');
     });
 
-    it.skip('[P2] should expose aria-labels on the native color inputs', () => {
+    it('[P2] should expose aria-labels on the native color inputs', () => {
       expect(fixture.nativeElement.querySelector('[data-testid="color-primary"]')?.getAttribute('aria-label')).toBe('Primary color');
       expect(fixture.nativeElement.querySelector('[data-testid="color-secondary"]')?.getAttribute('aria-label')).toBe('Secondary color');
     });
   });
 
   describe('Hex Validation (AC: 2)', () => {
-    it.skip('[P0] should show an error message for an invalid hex color', () => {
+    it('[P0] should show an error message for an invalid hex color', () => {
       component.primaryColor.set('red');
       fixture.detectChanges();
 
@@ -135,7 +139,7 @@ describe('BrandingPageComponent', () => {
       expect(alert?.textContent.toLowerCase()).toContain('hex');
     });
 
-    it.skip('[P0] should disable Complete while hex colors are invalid', () => {
+    it('[P0] should disable Complete while hex colors are invalid', () => {
       component.primaryColor.set('12345');
       fixture.detectChanges();
 
@@ -143,7 +147,7 @@ describe('BrandingPageComponent', () => {
       expect(completeButton?.disabled).toBe(true);
     });
 
-    it.skip('[P1] should accept valid hex colors case-insensitively', () => {
+    it('[P1] should accept valid hex colors case-insensitively', () => {
       component.primaryColor.set('#aAbBcC');
       component.secondaryColor.set('#AaBbCc');
       fixture.detectChanges();
@@ -152,7 +156,7 @@ describe('BrandingPageComponent', () => {
       expect(fixture.nativeElement.querySelector('[data-testid="complete-button"]')?.disabled).toBe(false);
     });
 
-    it.skip('[P2] should announce validation errors via role="alert"', () => {
+    it('[P2] should announce validation errors via role="alert"', () => {
       component.primaryColor.set('not-a-color');
       fixture.detectChanges();
 
@@ -161,21 +165,25 @@ describe('BrandingPageComponent', () => {
   });
 
   describe('Custom Field (AC: 3)', () => {
-    it.skip('[P0] should render label, required, and enabled controls', () => {
+    it('[P0] should render label, required, and enabled controls', () => {
       expect(fixture.nativeElement.querySelector('[data-testid="custom-field-label"]')).toBeTruthy();
       expect(fixture.nativeElement.querySelector('[data-testid="custom-field-required"]')).toBeTruthy();
       expect(fixture.nativeElement.querySelector('[data-testid="custom-field-enabled"]')).toBeTruthy();
     });
 
-    it.skip('[P0] should default the custom field to disabled', () => {
+    it('[P0] should default the custom field to disabled', () => {
       expect(component.customFieldLabel()).toBe('');
       expect(component.customFieldRequired()).toBe(false);
       expect(component.customFieldEnabled()).toBe(false);
     });
 
-    it.skip('[P1] should pre-fill the custom field from restaurant.customField', async () => {
+    it('[P1] should pre-fill the custom field from restaurant.customField', async () => {
       onboardingServiceSpy.getRestaurantByOwner.mockResolvedValue(BRANDED_RESTAURANT_FIXTURE);
 
+      fixture = TestBed.createComponent(BrandingPageComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      await fixture.whenStable();
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
@@ -186,7 +194,7 @@ describe('BrandingPageComponent', () => {
       expect(fixture.nativeElement.querySelector('[data-testid="custom-field-label"]')?.value).toBe('Dietary notes');
     });
 
-    it.skip('[P1] should update customFieldLabel when the label input changes', () => {
+    it('[P1] should update customFieldLabel when the label input changes', () => {
       const labelInput = fixture.nativeElement.querySelector('[data-testid="custom-field-label"]');
       labelInput.value = 'Allergies';
       labelInput.dispatchEvent(new Event('input'));
@@ -195,7 +203,7 @@ describe('BrandingPageComponent', () => {
       expect(component.customFieldLabel()).toBe('Allergies');
     });
 
-    it.skip('[P2] should update customFieldRequired from the required toggle', () => {
+    it('[P2] should update customFieldRequired from the required toggle', () => {
       component.customFieldRequired.set(true);
       fixture.detectChanges();
 
@@ -205,7 +213,7 @@ describe('BrandingPageComponent', () => {
   });
 
   describe('Skip (AC: 4)', () => {
-    it.skip('[P0] should save only { onboardingCompleted: true } on Skip', async () => {
+    it('[P0] should save only { onboardingCompleted: true } on Skip', async () => {
       vi.spyOn(router, 'navigate').mockResolvedValue(true);
 
       component.primaryColor.set('#FF0000');
@@ -221,7 +229,7 @@ describe('BrandingPageComponent', () => {
       });
     });
 
-    it.skip('[P0] should not save whiteLabel or customField on Skip', async () => {
+    it('[P0] should not save whiteLabel or customField on Skip', async () => {
       vi.spyOn(router, 'navigate').mockResolvedValue(true);
 
       fixture.nativeElement.querySelector('[data-testid="skip-link"]')?.click();
@@ -233,7 +241,7 @@ describe('BrandingPageComponent', () => {
       expect(payload).not.toHaveProperty('customField');
     });
 
-    it.skip('[P1] should navigate to /dashboard on Skip', async () => {
+    it('[P1] should navigate to /dashboard on Skip', async () => {
       const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
 
       fixture.nativeElement.querySelector('[data-testid="skip-link"]')?.click();
@@ -245,7 +253,7 @@ describe('BrandingPageComponent', () => {
   });
 
   describe('Complete (AC: 5)', () => {
-    it.skip('[P0] should save whiteLabel, customField, and onboardingCompleted: true', async () => {
+    it('[P0] should save whiteLabel, customField, and onboardingCompleted: true', async () => {
       vi.spyOn(router, 'navigate').mockResolvedValue(true);
 
       component.primaryColor.set('#336699');
@@ -266,7 +274,7 @@ describe('BrandingPageComponent', () => {
       });
     });
 
-    it.skip('[P0] should persist customField even when the custom field is disabled', async () => {
+    it('[P0] should persist customField even when the custom field is disabled', async () => {
       vi.spyOn(router, 'navigate').mockResolvedValue(true);
 
       fixture.nativeElement.querySelector('[data-testid="complete-button"]')?.click();
@@ -280,7 +288,7 @@ describe('BrandingPageComponent', () => {
       });
     });
 
-    it.skip('[P1] should navigate to /dashboard on Complete', async () => {
+    it('[P1] should navigate to /dashboard on Complete', async () => {
       const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
 
       fixture.nativeElement.querySelector('[data-testid="complete-button"]')?.click();
@@ -290,7 +298,7 @@ describe('BrandingPageComponent', () => {
       expect(navigateSpy).toHaveBeenCalledWith(['/dashboard']);
     });
 
-    it.skip('[P1] should disable Complete with aria-busy while saving', async () => {
+    it('[P1] should disable Complete with aria-busy while saving', async () => {
       vi.spyOn(router, 'navigate').mockResolvedValue(true);
 
       const completeButton = fixture.nativeElement.querySelector('[data-testid="complete-button"]');
@@ -304,7 +312,7 @@ describe('BrandingPageComponent', () => {
       fixture.detectChanges();
     });
 
-    it.skip('[P1] should show the save error and not navigate when the update fails', async () => {
+    it('[P1] should show the save error and not navigate when the update fails', async () => {
       const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
       onboardingServiceSpy.updateRestaurant.mockRejectedValueOnce(new Error('Save failed'));
 
@@ -316,7 +324,7 @@ describe('BrandingPageComponent', () => {
       expect(navigateSpy).not.toHaveBeenCalled();
     });
 
-    it.skip('[P1] should enable Complete when colors are valid', () => {
+    it('[P1] should enable Complete when colors are valid', () => {
       const completeButton = fixture.nativeElement.querySelector('[data-testid="complete-button"]');
       expect(completeButton?.disabled).toBe(false);
     });

--- a/src/app/onboarding/branding-page/branding-page.component.spec.ts
+++ b/src/app/onboarding/branding-page/branding-page.component.spec.ts
@@ -320,7 +320,7 @@ describe('BrandingPageComponent', () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      expect(fixture.nativeElement.querySelector('[role="alert"]')?.textContent).toContain('Save failed');
+      expect(fixture.nativeElement.querySelector('[role="alert"]')?.textContent).toContain('Something went wrong');
       expect(navigateSpy).not.toHaveBeenCalled();
     });
 

--- a/src/app/onboarding/branding-page/branding-page.component.ts
+++ b/src/app/onboarding/branding-page/branding-page.component.ts
@@ -1,0 +1,161 @@
+import { Component, computed, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButton } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatCheckbox } from '@angular/material/checkbox';
+import { MatInput, MatFormField, MatLabel } from '@angular/material/input';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { Router } from '@angular/router';
+import { OnboardingService } from '../../services/onboarding.service';
+
+const DESIGN_PRIMARY = '#1A1A1A';
+const DESIGN_SECONDARY = '#8FA67A';
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+@Component({
+  templateUrl: './branding-page.component.html',
+  styleUrls: ['./branding-page.component.scss'],
+  imports: [
+    FormsModule,
+    MatButton,
+    MatCardModule,
+    MatInput,
+    MatFormField,
+    MatLabel,
+    MatProgressBar,
+    MatCheckbox,
+  ],
+})
+export class BrandingPageComponent implements OnInit {
+  private onboardingService = inject(OnboardingService);
+  private router = inject(Router);
+
+  loading = signal(false);
+  error = signal<string | null>(null);
+
+  primaryColor = signal<string>(DESIGN_PRIMARY);
+  secondaryColor = signal<string>(DESIGN_SECONDARY);
+  customFieldLabel = signal<string>('');
+  customFieldRequired = signal<boolean>(false);
+  customFieldEnabled = signal<boolean>(false);
+
+  hexError = computed(() => {
+    if (!HEX_COLOR_PATTERN.test(this.primaryColor())) {
+      return 'Enter a valid hex color for the primary color (e.g. #1A1A1A)';
+    }
+    if (!HEX_COLOR_PATTERN.test(this.secondaryColor())) {
+      return 'Enter a valid hex color for the secondary color (e.g. #8FA67A)';
+    }
+    return null;
+  });
+
+  canComplete = computed(() => this.hexError() === null && !this.loading());
+
+  async ngOnInit() {
+    this.loading.set(true);
+    try {
+      const user = this.onboardingService.getCurrentUser();
+      if (!user) return;
+
+      const restaurant = await this.onboardingService.getRestaurantByOwner(user.uid);
+      if (!restaurant) return;
+
+      if (restaurant.whiteLabel) {
+        this.primaryColor.set(restaurant.whiteLabel.primaryColor);
+        this.secondaryColor.set(restaurant.whiteLabel.secondaryColor);
+      }
+
+      if (restaurant.customField) {
+        this.customFieldLabel.set(restaurant.customField.label);
+        this.customFieldRequired.set(restaurant.customField.required);
+        this.customFieldEnabled.set(restaurant.customField.enabled);
+      }
+    } catch {
+      // Silently ignore — defaults will be used
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  onPrimaryHexChange(value: string) {
+    this.primaryColor.set(value);
+  }
+
+  onSecondaryHexChange(value: string) {
+    this.secondaryColor.set(value);
+  }
+
+  onPrimarySwatchChange(value: string) {
+    this.primaryColor.set(value);
+  }
+
+  onSecondarySwatchChange(value: string) {
+    this.secondaryColor.set(value);
+  }
+
+  onCustomFieldLabelChange(value: string) {
+    this.customFieldLabel.set(value);
+  }
+
+  async completeOnboarding() {
+    if (!this.canComplete()) return;
+
+    this.loading.set(true);
+    this.error.set(null);
+
+    try {
+      const restaurantId = await this.getRestaurantId();
+      await this.onboardingService.updateRestaurant(restaurantId, {
+        whiteLabel: {
+          primaryColor: this.primaryColor(),
+          secondaryColor: this.secondaryColor(),
+        },
+        customField: {
+          label: this.customFieldLabel(),
+          required: this.customFieldRequired(),
+          enabled: this.customFieldEnabled(),
+        },
+        onboardingCompleted: true,
+      });
+
+      this.router.navigate(['/dashboard']);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Something went wrong. Please try again.';
+      this.error.set(message);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async skipOnboarding(event: Event) {
+    event.preventDefault();
+    if (this.loading()) return;
+
+    this.loading.set(true);
+    this.error.set(null);
+
+    try {
+      const restaurantId = await this.getRestaurantId();
+      await this.onboardingService.updateRestaurant(restaurantId, {
+        onboardingCompleted: true,
+      });
+
+      this.router.navigate(['/dashboard']);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Something went wrong. Please try again.';
+      this.error.set(message);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  private async getRestaurantId(): Promise<string> {
+    const user = this.onboardingService.getCurrentUser();
+    if (!user) throw new Error('User not authenticated');
+
+    const restaurant = await this.onboardingService.getRestaurantByOwner(user.uid);
+    if (!restaurant) throw new Error('Restaurant not found');
+
+    return restaurant.id;
+  }
+}

--- a/src/app/onboarding/branding-page/branding-page.component.ts
+++ b/src/app/onboarding/branding-page/branding-page.component.ts
@@ -29,8 +29,11 @@ const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 export class BrandingPageComponent implements OnInit {
   private onboardingService = inject(OnboardingService);
   private router = inject(Router);
+  private restaurantId: string | null = null;
 
   loading = signal(false);
+  saving = signal(false);
+  prefillFailed = signal(false);
   error = signal<string | null>(null);
 
   primaryColor = signal<string>(DESIGN_PRIMARY);
@@ -49,7 +52,9 @@ export class BrandingPageComponent implements OnInit {
     return null;
   });
 
-  canComplete = computed(() => this.hexError() === null && !this.loading());
+  busy = computed(() => this.loading() || this.saving());
+
+  canComplete = computed(() => this.hexError() === null && !this.busy() && !this.prefillFailed());
 
   async ngOnInit() {
     this.loading.set(true);
@@ -60,18 +65,22 @@ export class BrandingPageComponent implements OnInit {
       const restaurant = await this.onboardingService.getRestaurantByOwner(user.uid);
       if (!restaurant) return;
 
+      this.restaurantId = restaurant.id;
+
       if (restaurant.whiteLabel) {
-        this.primaryColor.set(restaurant.whiteLabel.primaryColor);
-        this.secondaryColor.set(restaurant.whiteLabel.secondaryColor);
+        this.primaryColor.set(restaurant.whiteLabel.primaryColor ?? DESIGN_PRIMARY);
+        this.secondaryColor.set(restaurant.whiteLabel.secondaryColor ?? DESIGN_SECONDARY);
       }
 
       if (restaurant.customField) {
-        this.customFieldLabel.set(restaurant.customField.label);
-        this.customFieldRequired.set(restaurant.customField.required);
-        this.customFieldEnabled.set(restaurant.customField.enabled);
+        this.customFieldLabel.set(restaurant.customField.label ?? '');
+        this.customFieldRequired.set(restaurant.customField.required ?? false);
+        this.customFieldEnabled.set(restaurant.customField.enabled ?? false);
       }
-    } catch {
-      // Silently ignore — defaults will be used
+    } catch (e: unknown) {
+      console.error('Failed to prefill branding settings', e);
+      this.prefillFailed.set(true);
+      this.error.set('Unable to load your saved settings. Please refresh and try again.');
     } finally {
       this.loading.set(false);
     }
@@ -98,14 +107,13 @@ export class BrandingPageComponent implements OnInit {
   }
 
   async completeOnboarding() {
-    if (!this.canComplete()) return;
+    if (!this.canComplete() || !this.restaurantId) return;
 
-    this.loading.set(true);
+    this.saving.set(true);
     this.error.set(null);
 
     try {
-      const restaurantId = await this.getRestaurantId();
-      await this.onboardingService.updateRestaurant(restaurantId, {
+      await this.onboardingService.updateRestaurant(this.restaurantId, {
         whiteLabel: {
           primaryColor: this.primaryColor(),
           secondaryColor: this.secondaryColor(),
@@ -120,42 +128,36 @@ export class BrandingPageComponent implements OnInit {
 
       this.router.navigate(['/dashboard']);
     } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : 'Something went wrong. Please try again.';
-      this.error.set(message);
+      console.error('Failed to complete onboarding', e);
+      this.error.set('Something went wrong. Please try again.');
     } finally {
-      this.loading.set(false);
+      this.saving.set(false);
     }
   }
 
   async skipOnboarding(event: Event) {
     event.preventDefault();
-    if (this.loading()) return;
+    if (this.busy()) return;
 
-    this.loading.set(true);
+    if (!this.restaurantId) {
+      this.error.set('Unable to load your restaurant. Please refresh and try again.');
+      return;
+    }
+
+    this.saving.set(true);
     this.error.set(null);
 
     try {
-      const restaurantId = await this.getRestaurantId();
-      await this.onboardingService.updateRestaurant(restaurantId, {
+      await this.onboardingService.updateRestaurant(this.restaurantId, {
         onboardingCompleted: true,
       });
 
       this.router.navigate(['/dashboard']);
     } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : 'Something went wrong. Please try again.';
-      this.error.set(message);
+      console.error('Failed to skip onboarding', e);
+      this.error.set('Something went wrong. Please try again.');
     } finally {
-      this.loading.set(false);
+      this.saving.set(false);
     }
-  }
-
-  private async getRestaurantId(): Promise<string> {
-    const user = this.onboardingService.getCurrentUser();
-    if (!user) throw new Error('User not authenticated');
-
-    const restaurant = await this.onboardingService.getRestaurantByOwner(user.uid);
-    if (!restaurant) throw new Error('Restaurant not found');
-
-    return restaurant.id;
   }
 }

--- a/src/app/services/onboarding.service.ts
+++ b/src/app/services/onboarding.service.ts
@@ -59,8 +59,8 @@ export class OnboardingService {
         hours: {},
         tableGroups: [],
         whiteLabel: {
-          primaryColor: '#000000',
-          secondaryColor: '#FFFFFF',
+          primaryColor: '#1A1A1A',
+          secondaryColor: '#8FA67A',
         },
         onboardingCompleted: false,
         createdAt: new Date(),


### PR DESCRIPTION
## Summary

Implements the branding step (Step 3 of 3) of onboarding: heading, Skip link, primary/secondary hex color pickers with native swatches, custom field (label + required/enabled), Complete with loading/error states, and the `/onboarding/branding` route.

## What's included

- Branding page component (signals, prefill from `restaurant.whiteLabel`/`customField`, hex validation, Complete/Skip save via `updateRestaurant`)
- `createRestaurant` whiteLabel defaults changed to DESIGN palette (`#1A1A1A` / `#8FA67A`)
- `/onboarding/branding` route (lazy, guarded by `[isAuthenticatedGuard, isNotOnboardedGuard]`)
- 26 unit tests + 7 E2E tests

## Code review (bmad-code-review)

All 6 patch findings from the review were applied and verified:

1. **High** — Silent prefill failure can no longer wipe saved branding: prefill read failures now set `prefillFailed`, block Complete, and surface an error instead of swallowing.
2. **Medium** — `loading()` no longer conflates prefill and save: split into `loading`/graph `saving`, button shows "Saving..." only during the actual write.
3. **Medium** — Removed the per-submit `getRestaurantId()` Firestore re-query (extra read + TOCTOU): restaurant id captured once in `ngOnInit`.
4. **Low** — Defensive `??` guards on partial `whiteLabel`/`customField` sub-fields during prefill.
5. **Low** — Raw SDK error messages replaced with generic copy (raw error logged).
6. **Low** — Skip link a11y: `tabindex` removed while busy so it is no longer keyboard-focusable when disabled.

Validation: lint clean, 142/142 unit tests, 7/7 branding E2E, build success.