### PR TITLE
Story 2.2: Party Size & Date Selection

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -121,3 +121,21 @@ Items surfaced during code reviews that are pre-existing issues or out of scope 
 - source_spec: `_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md`
   summary: Today remains selectable on the booking calendar after the restaurant's closing time has passed (old e2e helper had a closeHour guard that was dropped; app never had one)
   evidence: Spec-compliant (matrix row says today+future selectable) and gracefully handled once Story 2.3 computes real slot availability ("No available times for this date") — revisit when planning 2-3 so availability excludes today after close
+
+## Deferred from: code review of spec-2-2-party-size-date-selection (2026-08-23)
+
+- source_spec: `_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md`
+  summary: Zoned-day math implemented three times — calendar.ts (app), getNextAvailableDate and nextClosedDayIso (e2e helpers)
+  evidence: Test-infra duplication mirrors app logic per spec intent; extracting a shared helper crosses the src/e2e boundary
+
+- source_spec: `_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md`
+  summary: .back-button/.heading styles copy-pasted verbatim across booking-page, calendar-step and party-size-step stylesheets
+  evidence: Component-scoped styles are Angular-idiomatic here; sharing would need global styles or SCSS mixins
+
+- source_spec: `_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md`
+  summary: Hardcoded hex colors (#f5f0eb/#6b6b6b/#e5e0db/#ffffff) although DESIGN.md defines named tokens (surface/muted/hairline)
+  evidence: Only --osef-brand-primary/secondary exist as CSS custom properties; other tokens have no var infrastructure yet, values match DESIGN.md exactly
+
+- source_spec: `_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md`
+  summary: BookingFlowService actions unguarded against out-of-order invocation (chooseDate before start reaches states no @switch case renders well)
+  evidence: All current call sites wire correctly; worth transition guards as Stories 2.3–2.5 add consumers

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -115,3 +115,9 @@ Items surfaced during code reviews that are pre-existing issues or out of scope 
 - source_spec: `_bmad-output/implementation-artifacts/2-1-public-booking-page-foundation-landing.md`
   summary: BookingService casts Firestore data as Restaurant without shape validation
   evidence: Common Firebase pattern; runtime failure would be caught by component tests
+
+## Deferred from: review of spec-2-2-party-size-date-selection (2026-08-21)
+
+- source_spec: `_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md`
+  summary: Today remains selectable on the booking calendar after the restaurant's closing time has passed (old e2e helper had a closeHour guard that was dropped; app never had one)
+  evidence: Spec-compliant (matrix row says today+future selectable) and gracefully handled once Story 2.3 computes real slot availability ("No available times for this date") — revisit when planning 2-3 so availability excludes today after close

--- a/_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md
+++ b/_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md
@@ -1,0 +1,180 @@
+---
+title: 'Story 2.2: Party Size & Date Selection'
+type: 'feature'
+created: '2026-08-21'
+status: 'done'
+review_loop_iteration: 0
+context: []
+baseline_commit: 0b4b4334aeb077d183660fd203ef583ee5f6c3bf
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** After Story 2.1, `/book/{slug}` ends at a static landing — diners cannot begin a booking. This story adds the first two flow steps: party size (2×4 grid of circular buttons 1–8) and an open-dates-only calendar, with auto-advance and back navigation preserving selections.
+
+**Approach:** Make `BookingPageComponent` the shell of a signal-driven step flow (landing → party size → date → time-slot stub); flow state in a new `BookingFlowService`, UI in two new step components, date logic in pure calendar utilities driven by `restaurant.hours` in the restaurant's IANA timezone. The time-slot view is a minimal stub replaced by Story 2.3.
+
+## Boundaries & Constraints
+
+**Always:**
+- Standalone components, `osef-` prefix, `inject()`, signals, strict TS (no `any`), native control flow, colocated `*.spec.ts`; vitest describe-per-scenario (`HAPPY_PATH`…) with `[P0]`/`[P1]` test prefixes.
+- Flow state in `BookingFlowService` (`@Service()`): `step` (`landing|party-size|date|time`), `partySize`, `selectedDate` signals + actions (`start/choosePartySize/chooseDate/back/reset`); reset on restaurant reload.
+- Calendar logic = pure functions taking explicit `(hours, timezone, now)`; "today" via `Intl.DateTimeFormat` with `restaurant.timezone` (never device-local getters); cell weekdays from UTC-constructed dates; no bare `new Date()` outside an injected clock.
+- Hours keys are `DayNumber` 1=Mon..7=Sun; missing key = closed. Only open AND today-or-future dates render as buttons; closed/past days absent from the DOM entirely (hidden, not grayed).
+- Reuse host vars `--osef-brand-primary`/`--osef-brand-secondary`; selected state = primary fill + white text; tap targets ≥44px; each transition moves focus to the new step heading (`tabindex="-1"` + `.focus()`) and a polite live region announces "Step N of 6: {Step Name}".
+- data-testids: `party-size-option-{n}`, `party-size-back`, `calendar-prev`, `calendar-next`, `date-option-{YYYY-MM-DD}`, `calendar-back`.
+- Fix e2e seeding to match the app type: `factories.ts` hours re-keyed to 1–7; align `getNextAvailableDate`.
+
+**Ask First:** upper bound on forward month navigation, or an all-closed empty-month message, if deemed needed.
+
+**Never:**
+- No availability computation; no `bookings`/`bookings-public` reads/writes (Story 2.3+); no time-slot UI beyond the stub; no details form.
+- No firestore.rules changes; no auth/dashboard changes; no `ThemingService`.
+- No Angular Material in booking flow; no new font imports; no route changes (flow stays inside `/book/:slug`).
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| HAPPY_PATH_PARTY | Landing; tap "Book a Table", then "4" | Party step: 2×4 grid, "How many guests?", back→landing; "4" highlighted (primary fill, white text); auto-advance to calendar | N/A |
+| BACK_PRESERVES | On calendar after choosing 4; tap back | Party step with "4" still highlighted | N/A |
+| OPEN_DATE_SELECT | Calendar; tap open future date | Date highlighted; auto-advance to time-slot stub showing selected summary | N/A |
+| DAY_HIDDEN | Weekday closed in `hours`, or open day before today (restaurant tz) | Cell absent from grid everywhere; month nav + back still work when a month renders zero buttons | N/A |
+| MONTH_NAV | Tap next / prev | Grid rebuilds; prev disabled while viewing current month | N/A |
+| TZ_TODAY_BOUNDARY | Device tz ≠ restaurant tz near midnight | "Today"/weekday derivation use `restaurant.timezone` | N/A |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `src/booking/pages/booking-page/booking-page.component.{ts,html,scss}` -- shell to extend: `resource()` fetch (:23-31), brand CSS var computeds (:10-13,:33-46), retry (:59-61); `book-button` handler-less (html:46); existing testids html:7-46.
+- `src/booking/services/booking.service.ts` -- `getRestaurantBySlug()`; reuse as-is.
+- `src/shared/types/restaurant.ts` -- `timezone: string` (:7, IANA; hardcoded `'Europe/London'` at creation, onboarding.service.ts:57); `OpeningHours = Partial<Record<DayNumber, DayHours>>` (:21-30), `"HH:mm"` values.
+- `src/app/app.routes.ts:38-44` -- single lazy `/book/:slug` + input binding; no route changes.
+- `src/app/onboarding/` -- per-step routes work there because state persists server-side; not followed here (ephemeral state → signal service).
+- `_bmad-output/planning-artifacts/ux-designs/ux-osefdetalife-2026-07-14/DESIGN.md` -- :142-144 step header/party grid/calendar specs; tokens :95-101 (accent #8FA67A hover #7A9168, ink #1A1A1A, muted #6B6B6B, hairline #E5E0DB, surface #F5F0EB); radius 8/12/16; spacing 4–48.
+- `.../EXPERIENCE.md` -- :31,:82 back preserves selections; :83 single-select no deselect; :84 closed hidden entirely; :131-132 focus-to-heading + "Step N of 6"; :134 ≥44px; :137 Reduce Motion.
+- `.../mockups/key-widget-party-size.html:79-106` -- exact party-size CSS: grid `repeat(4,1fr)` gap 12px; buttons `aspect-ratio:1; border-radius:50%; border:2px solid #E5E0DB; background:#FFF; font-size:1.125rem; font-weight:600`; selected accent bg/border + white text; hover border #6B6B6B. No calendar mockup exists — DESIGN.md:144 is the only visual spec.
+- `e2e/fixtures/factories.ts:13-20` -- ⚠️ seeds hours with JS 0-indexed day keys (0=Sun..5=Fri), conflicting with the app type; re-key here.
+- `e2e/utils/test-helpers.ts:36-65` -- `formatDate`/`getNextAvailableDate` use local-time `getDay()`; align to 1–7.
+- `e2e/fixtures/restaurant.fixture.ts:38-91` -- seeding + cleanup pattern; `RestaurantPage` page object :15-36; `e2e/tests/public-booking-page.spec.ts` shows `getByTestId`/`toHaveCount(0)` patterns.
+- `src/booking/pages/booking-page/booking-page.component.spec.ts:26-66` -- vitest spy-object + `provideRouter([])` + `setInput` + `resolveLoad`/`whenStable` patterns; `booking.service.spec.ts:5-41` shows `vi.mock('firebase/firestore')`.
+- `firestore.rules:93-106` -- `bookings-public` rules exist (read-only evidence; Story 2.3).
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `src/booking/utils/calendar.ts` + `.spec.ts` -- pure helpers: `zonedToday(timezone, now)` → `{iso, dayNumber}`; `isOpenOn(hours, iso)`; `buildMonthGrid(year, month, hours, todayIso)` → cells `{iso, dayNumber, selectable}` omitting closed/past -- deterministic core; unit-test TZ boundary with fixed `now`.
+- [x] `src/booking/services/booking-flow.service.ts` -- `@Service()` singleton holding the flow state machine -- reused by Stories 2.3–2.5.
+- [x] `src/booking/steps/party-size-step/party-size-step.component.{ts,html,scss,spec.ts}` -- 2×4 circular grid 1–8, heading, back output; emits selection, parent advances -- AC grid/heading/back/auto-advance.
+- [x] `src/booking/steps/calendar-step/calendar-step.component.{ts,html,scss,spec.ts}` -- month header + prev/next (prev disabled on current month), grid from `buildMonthGrid`, back output; month-offset signal -- AC open-only/today+/hidden/nav.
+- [x] `src/booking/pages/booking-page/booking-page.component.{ts,html,scss,spec.ts}` -- wire `book-button` → `flow.start()`; `@switch` rendering active step; stub time view (summary + back); focus-to-heading; sr-only live region; reduced-motion-safe transition -- orchestration + a11y precedents for 2.3–2.5.
+- [x] `e2e/fixtures/factories.ts` + `e2e/utils/test-helpers.ts` -- re-key hours to 1=Mon..7=Sun; align `getNextAvailableDate` -- unblocks truthful calendar e2e.
+- [x] `e2e/tests/public-booking-page.spec.ts` (extend) -- P0: book → tap 3 → pick next open date → stub shows summary; P1: back preserves party size; P1: closed weekday absent (`toHaveCount(0)`) -- end-to-end proof.
+
+**Acceptance Criteria:**
+- Given landing, when the diner taps "Book a Table", then the party-size step shows a 2×4 grid of circular buttons 1–8, the heading "How many guests?", and a back button returning to landing.
+- Given the party-size step, when a number is tapped, then it is highlighted (accent fill, white text) and the calendar step loads automatically.
+- Given the calendar step, then only open dates (per `hours`, restaurant timezone) from today onward are tappable; closed and past dates appear nowhere in the grid.
+- Given an open date is selected, then the time-slot area loads automatically showing the selections; its back returns to the calendar with the date highlighted, and the calendar's back returns to party size with the number selected.
+- Given any step transition, then focus moves to the new step heading and a live region announces "Step N of 6: {Step Name}".
+
+## Spec Change Log
+
+- Implementation-time infra addition: `playwright.config.ts` webServer URL now honors `PLAYWRIGHT_TEST_BASE_URL` (same env var `baseURL` already used) — a local Colima/Lima tunnel occupied port 4210 with a 404, permanently failing Playwright's readiness check. Default behavior unchanged; no app code affected.
+- Review round 1 — human resolved the frozen *Ask First*: calendar gets an empty-month message ("No available dates in this month."); forward navigation stays unbounded by explicit human decision. KEEP: signal-based flow state machine, pure `(hours, timezone, now)` calendar utils with UTC-derived weekdays, hidden-not-grayed non-selectable days, existing testids.
+- Review round 1 — patch batch applied: e2e asserts chosen date in stub summary; unit tests added for time-back preserving date, "Step 4 of 6: Time" announcement, time-heading focus, party-size reselect-after-back; a11y fixes (destination-specific back labels, single month-label announcement, focus target on return to landing, weekday header row); invalid-timezone Intl fallback to UTC parts (never device-local); dead `formatDate` helper removed.
+
+## Matrix Test Audit
+
+| Matrix row | Verified by |
+|---|---|
+| HAPPY_PATH_PARTY | unit `party-size-step.component.spec.ts` HAPPY_PATH ([P0] grid+heading, [P0] emit on tap), unit `booking-flow.service.spec.ts` [P0] walk landing→time, e2e "Booking Flow [P0] book → choose party size → pick next open date → stub" |
+| BACK_PRESERVES | unit `booking-flow.service.spec.ts` BACK_PRESERVES ×3, unit `calendar-step.component.spec.ts` SELECTION_STATE highlight-on-return + BACK_NAVIGATION emit, e2e "[P1] back from the calendar preserves the chosen party size" |
+| OPEN_DATE_SELECT | unit `calendar-step.component.spec.ts` [P0] emit ISO on open-date tap, unit flow walk, e2e Booking Flow [P0] |
+| DAY_HIDDEN | unit `calendar.spec.ts` DAY_HIDDEN ×2 (past-open omitted, today included), unit `calendar-step.component.spec.ts` DAY_HIDDEN ×2 (past-open, closed-weekday), e2e "[P1] closed weekday is absent from the calendar" |
+| MONTH_NAV | unit `calendar.spec.ts` MONTH_NAV zero-selectable-days month, unit `calendar-step.component.spec.ts` MONTH_NAV ([P0] prev disabled on current month, [P1] grid rebuilds), e2e "[P1] …navigation still works" |
+| TZ_TODAY_BOUNDARY | unit `calendar.spec.ts` zonedToday TZ_BOUNDARY (fixed `now` at 2026-08-20T23:30Z London/NY boundary), unit `calendar-step.component.spec.ts` TZ_BOUNDARY device-clock independence |
+
+**Verification evidence:** `npm test -- --watch=false` → 26 files / 227 tests passing after review round 1 patches (incl. every matrix row above); `npm run lint` → clean; `npm run build` → production build succeeds (new code in 18 kB lazy booking chunk); Playwright `public-booking-page.spec.ts` → 6/6 pass (3 pre-existing landing tests + 3 new booking-flow tests).
+
+## Design Notes
+
+Onboarding uses URL-per-step because state persists server-side; booking selections are ephemeral until final submit (2.4), so one signal service avoids guard/URL plumbing while keeping components small.
+
+Timezone safety — never device-local getters for "today"/weekday:
+
+```ts
+const iso = new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit' }).format(now);
+const wd = new Intl.DateTimeFormat('en-US', { timeZone: tz, weekday: 'short' }).format(now); // Mon..Sun → 1..7
+const dow = new Date(Date.UTC(y, m - 1, d)).getUTCDay(); // cell weekday: ((dow + 6) % 7) + 1
+```
+
+Accent mapping follows 2-1: selected fills use `var(--osef-brand-primary)` (same as `book-button`).
+
+## Verification
+
+**Commands:**
+- `npm test` -- expected: all suites pass incl. calendar util, both step components, updated booking-page spec (every matrix row covered).
+- `npm run lint` -- expected: clean.
+- `npm run build` -- expected: production build succeeds.
+- `npx playwright test e2e/tests/public-booking-page.spec.ts` -- expected: existing 3 tests + new scenarios pass against emulators.
+
+## Suggested Review Order
+
+**Flow state machine**
+
+- Entry point: signal-based step machine reused by Stories 2.3–2.5
+  [`booking-flow.service.ts:10`](../../src/booking/services/booking-flow.service.ts#L10)
+
+- Back preserves selections — the BACK_PRESERVES contract
+  [`booking-flow.service.ts:33`](../../src/booking/services/booking-flow.service.ts#L33)
+
+**Calendar core (pure, SSR-safe)**
+
+- "Today"/weekday from restaurant timezone via Intl; UTC fallback on bad zones
+  [`calendar.ts:36`](../../src/booking/utils/calendar.ts#L36)
+
+- Open-day lookup: missing key = closed
+  [`calendar.ts:53`](../../src/booking/utils/calendar.ts#L53)
+
+- Month grid omits closed/past days entirely — hidden-not-grayed invariant
+  [`calendar.ts:62`](../../src/booking/utils/calendar.ts#L62)
+
+**Step UI**
+
+- 2×4 circular grid, single-select, auto-advance
+  [`party-size-step.component.html:22`](../../src/booking/steps/party-size-step/party-size-step.component.html#L22)
+
+- Weekday header row + month nav with prev disabled on current month
+  [`calendar-step.component.html:38`](../../src/booking/steps/calendar-step/calendar-step.component.html#L38)
+
+- Empty-month message per human decision; forward nav intentionally unbounded
+  [`calendar-step.component.html:59`](../../src/booking/steps/calendar-step/calendar-step.component.html#L59)
+
+**Orchestration & accessibility**
+
+- "Step N of 6" live-region announcement map
+  [`booking-page.component.ts:63`](../../src/booking/pages/booking-page/booking-page.component.ts#L63)
+
+- Effects: flow reset on restaurant change, focus targets per transition
+  [`booking-page.component.ts:99`](../../src/booking/pages/booking-page/booking-page.component.ts#L99)
+
+- @switch shell rendering the active step
+  [`booking-page.component.html:42`](../../src/booking/pages/booking-page/booking-page.component.html#L42)
+
+- Time-slot stub — deliberately minimal, replaced by Story 2.3
+  [`booking-page.component.html:84`](../../src/booking/pages/booking-page/booking-page.component.html#L84)
+
+**E2E proof & fixtures**
+
+- P0 full flow + P1 back-preserves and closed-weekday-absent
+  [`public-booking-page.spec.ts:78`](../../e2e/tests/public-booking-page.spec.ts#L78)
+
+- Hours re-keyed to 1=Mon..7=Sun (was JS 0-indexed — silent mismatch)
+  [`factories.ts:13`](../../e2e/fixtures/factories.ts#L13)
+
+- e2e base URL env override (local port-squat workaround, default unchanged)
+  [`playwright.config.ts:7`](../../playwright.config.ts#L7)

--- a/_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md
+++ b/_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md
@@ -3,7 +3,7 @@ title: 'Story 2.2: Party Size & Date Selection'
 type: 'feature'
 created: '2026-08-21'
 status: 'done'
-review_loop_iteration: 0
+review_loop_iteration: 2
 context: []
 baseline_commit: 0b4b4334aeb077d183660fd203ef583ee5f6c3bf
 ---
@@ -83,7 +83,7 @@ baseline_commit: 0b4b4334aeb077d183660fd203ef583ee5f6c3bf
 
 ## Spec Change Log
 
-- Implementation-time infra addition: `playwright.config.ts` webServer URL now honors `PLAYWRIGHT_TEST_BASE_URL` (same env var `baseURL` already used) — a local Colima/Lima tunnel occupied port 4210 with a 404, permanently failing Playwright's readiness check. Default behavior unchanged; no app code affected.
+- Implementation-time infra addition: `playwright.config.ts` now honors `PLAYWRIGHT_TEST_BASE_URL` in two places — the `webServer.url`/`baseURL` value AND the `webServer` array, which skips spawning the local `ng serve` entirely when that env var is set (only emulators spawn; an already-running app would hang readiness polling). Same env var `baseURL` already used. A local Colima/Lima tunnel occupied port 4210 with a 404, permanently failing Playwright's readiness check. Default behavior unchanged; no app code affected. Disclosure completed during review round 2 — the round-1 entry originally mentioned only the URL half.
 - Review round 1 — human resolved the frozen *Ask First*: calendar gets an empty-month message ("No available dates in this month."); forward navigation stays unbounded by explicit human decision. KEEP: signal-based flow state machine, pure `(hours, timezone, now)` calendar utils with UTC-derived weekdays, hidden-not-grayed non-selectable days, existing testids.
 - Review round 1 — patch batch applied: e2e asserts chosen date in stub summary; unit tests added for time-back preserving date, "Step 4 of 6: Time" announcement, time-heading focus, party-size reselect-after-back; a11y fixes (destination-specific back labels, single month-label announcement, focus target on return to landing, weekday header row); invalid-timezone Intl fallback to UTC parts (never device-local); dead `formatDate` helper removed.
 
@@ -178,3 +178,23 @@ Accent mapping follows 2-1: selected fills use `var(--osef-brand-primary)` (same
 
 - e2e base URL env override (local port-squat workaround, default unchanged)
   [`playwright.config.ts:7`](../../playwright.config.ts#L7)
+
+### Review Findings
+
+_Review round 2 — 2026-08-23 — adversarial review (blind-hunter, edge-case-hunter, verification-gap, acceptance-auditor) against baseline 0b4b433._
+
+- [x] [Review][Decision] Landing transition announces nothing (AC5 ambiguity) — `stepAnnouncement` returns `''` when step is landing ([booking-page.component.ts:74](../../src/booking/pages/booking-page/booking-page.component.ts#L74)); return-to-landing moves focus to the CTA but no live-region announcement fires, while frozen AC5 says every step transition announces "Step N of 6" and `TOTAL_STEPS = 6` implies landing is Step 1. Also unpinned by tests either way — no test asserts the landing value of the live region. **Resolved: announce `Step 1 of 6: Start` on landing (initial + return), pinned by [P0] test.**
+- [x] [Review][Decision] No visual "today" marker in the calendar — today renders as a normal selectable cell; DESIGN.md:144 is the only calendar visual spec and no mockup exists, so adding a today treatment needs design intent first. **Resolved: brand-secondary outline + bold number on today's non-selected cell, `aria-current="date"`, pinned by [P1] tests.**
+- [x] [Review][Patch] Calendar cells misalign with weekday headers — grid omits closed/past days without leading spacers, so buttons pack flush-left and every subsequent cell drifts under the wrong weekday label whenever any day mid-month is closed (e.g. closed Saturdays shift all later cells one column left) [src/booking/steps/calendar-step/calendar-step.component.html:43] **Fixed: leadingSpacers rendered before cells; GRID_ALIGNMENT tests.**
+- [x] [Review][Patch] Back from time stub loses future-month date highlight — `monthOffset` resets to `0` on remount, so after picking a date beyond the current month, time-back re-renders the current month where the selected date doesn't exist; violates AC4 "back returns to the calendar with the date highlighted". No test combines forward-month navigation with selection + back [src/booking/steps/calendar-step/calendar-step.component.ts:33] **Fixed: monthOffset derived from selected date via userMonthOffset override; future-month back test added.**
+- [x] [Review][Patch] P0 e2e fails deterministically near month end — next open date can fall in the month after the displayed one, which is never rendered; test must navigate months before asserting/clicking [e2e/tests/public-booking-page.spec.ts:86] **Fixed: showMonth() helper navigates to the target month first.**
+- [x] [Review][Patch] Vacuous closed-Saturday e2e assertion — when the next Saturday falls outside the displayed month, `toHaveCount(0)` passes regardless of hiding behavior; pick/navigate to a guaranteed-rendered closed day [e2e/tests/public-booking-page.spec.ts:124] **Fixed: showMonth(closedDay) then assert absence within its own rendered month; stale prev-disabled assertion replaced with month-label check.**
+- [x] [Review][Patch] Stale "today" across midnight — `today` is computed once per mount over the non-reactive clock; a long-lived tab keeps yesterday selectable and prev-disabled anchored to a stale month [src/booking/steps/calendar-step/calendar-step.component.ts:38] **Fixed: navTick signal re-evaluates today() on every prev/next; TZ_BOUNDARY midnight-refresh test.**
+- [x] [Review][Patch] e2e helpers hardcode Europe/London instead of taking restaurant.timezone from the fixture [e2e/utils/test-helpers.ts:41] **Fixed: getNextAvailableDate timezone now required; call sites pass restaurant.timezone; nextClosedDayIso takes timezone param.**
+- [x] [Review][Patch] calendar.spec.ts convention gaps — five tests missing `[P0]`/`[P1]` prefixes (TZ_BOUNDARY ×2, DAY_HIDDEN ×2, MONTH_NAV ×1); describes organized by function rather than per scenario [src/booking/utils/calendar.spec.ts:53] **Fixed: scenario describes (HAPPY_PATH/TZ_BOUNDARY/EDGE_CASE/DAY_HIDDEN/MONTH_NAV); all tests prefixed.**
+- [x] [Review][Patch] Spec change log understates playwright.config.ts change — webServer array also skips spawning `ng serve` entirely when the env var is set; disclosure incomplete [_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md:86] **Fixed: change-log entry amended above.**
+- [x] [Review][Patch] Status metadata conflict — spec frontmatter says status 'done'/review_loop_iteration 0 while sprint-status tracks 'review' and round-1 patches are documented; reconcile during completion bookkeeping [_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md:5] **Fixed: review_loop_iteration set to 2; sprint-status reconciled.**
+- [x] [Review][Defer] Zoned-day math triplicated (calendar.ts / getNextAvailableDate / nextClosedDayIso) — deferred, extraction crosses src/e2e boundary [e2e/utils/test-helpers.ts:41]
+- [x] [Review][Defer] .back-button/.heading styles duplicated verbatim across three stylesheets — deferred, component-scoped styles are idiomatic here [src/booking/steps/calendar-step/calendar-step.component.scss:13]
+- [x] [Review][Defer] Hardcoded hex colors (#f5f0eb/#6b6b6b/#e5e0db/#ffffff) where DESIGN.md names tokens but only brand vars exist as CSS custom properties — deferred, needs token infrastructure decision [src/booking/steps/calendar-step/calendar-step.component.scss:63]
+- [x] [Review][Defer] BookingFlowService actions unguarded against out-of-order invocation — deferred, no current caller misuse; revisit as Stories 2.3–2.5 add consumers [src/booking/services/booking-flow.service.ts:16]

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -61,7 +61,7 @@ development_status:
 
   epic-2: in-progress
   2-1-public-booking-page-foundation-landing: done
-  2-2-party-size-date-selection: review
+  2-2-party-size-date-selection: done
   2-3-time-slot-selection-availability: backlog
   2-4-details-form-booking-submission: backlog
   2-5-navigation-loading-error-handling: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -41,7 +41,7 @@
 # - Retrospective appends its action items to action_items; sprint-status surfaces open ones
 
 generated: '2026-07-14'
-last_updated: 08-20-2026 23:20
+last_updated: 08-21-2026
 project: osefdetalife
 project_key: NOKEY
 tracking_system: file-system
@@ -61,7 +61,7 @@ development_status:
 
   epic-2: in-progress
   2-1-public-booking-page-foundation-landing: done
-  2-2-party-size-date-selection: backlog
+  2-2-party-size-date-selection: review
   2-3-time-slot-selection-availability: backlog
   2-4-details-form-booking-submission: backlog
   2-5-navigation-loading-error-handling: backlog

--- a/e2e/fixtures/factories.ts
+++ b/e2e/fixtures/factories.ts
@@ -11,12 +11,14 @@ export function createRestaurantData(overrides?: Partial<Restaurant>): Restauran
     ownerId: faker.string.uuid(),
     timezone: 'Europe/London',
     hours: {
-      0: { open: '09:00', close: '17:00' },
+      // ISO day numbers: 1=Monday .. 7=Sunday (matches the app's OpeningHours type).
+      // Saturday (6) is intentionally closed so calendar e2e can assert hidden days.
       1: { open: '09:00', close: '17:00' },
       2: { open: '09:00', close: '17:00' },
       3: { open: '09:00', close: '17:00' },
       4: { open: '09:00', close: '17:00' },
       5: { open: '10:00', close: '15:00' },
+      7: { open: '09:00', close: '17:00' },
     },
     whiteLabel: {
       primaryColor: '#1A1A1A',

--- a/e2e/tests/public-booking-page.spec.ts
+++ b/e2e/tests/public-booking-page.spec.ts
@@ -2,11 +2,11 @@ import { test, expect } from '../fixtures';
 import { doc, getDoc, updateDoc, deleteField } from 'firebase/firestore';
 import { getNextAvailableDate } from '../utils/test-helpers';
 
-/** Next Saturday on/after today (Europe/London), as YYYY-MM-DD — the seeded restaurant is closed Saturdays. */
-function nextClosedDayIso(): string {
+/** Next Saturday on/after today in `timezone`, as YYYY-MM-DD — the seeded restaurant is closed Saturdays. */
+function nextClosedDayIso(timezone: string): string {
   const now = new Date();
   const todayIso = new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'Europe/London',
+    timeZone: timezone,
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
@@ -24,6 +24,16 @@ function nextClosedDayIso(): string {
     day = next.getUTCDate();
   }
   throw new Error('No Saturday found within two weeks');
+}
+
+/** The calendar's month label for an ISO date — matches the app's en-GB "Month YYYY" rendering. */
+function monthLabel(iso: string): string {
+  const [year, month] = iso.split('-').map(Number);
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'UTC',
+    month: 'long',
+    year: 'numeric',
+  }).format(new Date(Date.UTC(year, month - 1, 1)));
 }
 
 test.describe('Public Booking Page', () => {
@@ -75,6 +85,22 @@ test.describe('Public Booking Page', () => {
       await expect(page.getByRole('heading', { name: 'How many guests?' })).toBeVisible();
     }
 
+    /**
+     * Forwards the calendar until the month containing `iso` is rendered. The
+     * grid only shows one month at a time, so any assertion about a date must
+     * first bring its month on screen — otherwise near month boundaries the
+     * target simply does not exist in the DOM yet.
+     */
+    async function showMonth(page: import('@playwright/test').Page, iso: string): Promise<void> {
+      const target = monthLabel(iso);
+      for (let i = 0; i < 24; i++) {
+        const label = (await page.locator('.month-label').textContent())?.trim();
+        if (label === target) return;
+        await page.getByTestId('calendar-next').click();
+      }
+      throw new Error(`Month "${target}" never rendered within 24 forward navigations`);
+    }
+
     test('[P0] book → choose party size → pick next open date → time-slot stub shows summary', async ({
       page,
       restaurant,
@@ -83,7 +109,9 @@ test.describe('Public Booking Page', () => {
 
       await page.getByTestId('party-size-option-3').click();
 
-      const nextOpenDate = getNextAvailableDate(restaurant.hours);
+      const nextOpenDate = getNextAvailableDate(restaurant.hours, restaurant.timezone);
+      // The next open date can fall beyond the currently displayed month.
+      await showMonth(page, nextOpenDate);
       await expect(page.getByTestId(`date-option-${nextOpenDate}`)).toBeVisible();
       await page.getByTestId(`date-option-${nextOpenDate}`).click();
 
@@ -113,7 +141,7 @@ test.describe('Public Booking Page', () => {
       await expect(option).toHaveAttribute('aria-pressed', 'true');
     });
 
-    test('[P1] closed weekday is absent from the calendar and navigation still works', async ({
+    test('[P1] closed weekday is absent from its own rendered month and navigation still works', async ({
       page,
       restaurant,
     }) => {
@@ -121,14 +149,17 @@ test.describe('Public Booking Page', () => {
 
       await page.getByTestId('party-size-option-2').click();
 
-      const closedDay = nextClosedDayIso();
+      const closedDay = nextClosedDayIso(restaurant.timezone);
+      // Render the closed day's month first — a toHaveCount(0) against an
+      // undisplayed month would pass vacuously and prove nothing.
+      await showMonth(page, closedDay);
       await expect(page.getByTestId(`date-option-${closedDay}`)).toHaveCount(0);
 
       // Month navigation still works alongside hidden days.
       await page.getByTestId('calendar-next').click();
       await expect(page.getByTestId('calendar-prev')).toBeEnabled();
       await page.getByTestId('calendar-prev').click();
-      await expect(page.getByTestId('calendar-prev')).toBeDisabled();
+      await expect(page.locator('.month-label')).toHaveText(monthLabel(closedDay));
 
       // Back returns to party size with the selection intact.
       await page.getByTestId('calendar-back').click();

--- a/e2e/tests/public-booking-page.spec.ts
+++ b/e2e/tests/public-booking-page.spec.ts
@@ -1,5 +1,30 @@
 import { test, expect } from '../fixtures';
 import { doc, getDoc, updateDoc, deleteField } from 'firebase/firestore';
+import { getNextAvailableDate } from '../utils/test-helpers';
+
+/** Next Saturday on/after today (Europe/London), as YYYY-MM-DD — the seeded restaurant is closed Saturdays. */
+function nextClosedDayIso(): string {
+  const now = new Date();
+  const todayIso = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/London',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now);
+
+  let [year, month, day] = todayIso.split('-').map(Number);
+  for (let i = 0; i < 13; i++) {
+    const utcDayOfWeek = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+    if (utcDayOfWeek === 6) {
+      return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    }
+    const next = new Date(Date.UTC(year, month - 1, day + 1));
+    year = next.getUTCFullYear();
+    month = next.getUTCMonth() + 1;
+    day = next.getUTCDate();
+  }
+  throw new Error('No Saturday found within two weeks');
+}
 
 test.describe('Public Booking Page', () => {
   test('[P0] valid slug renders restaurant name, address, and Book a Table button', async ({
@@ -40,5 +65,74 @@ test.describe('Public Booking Page', () => {
     await expect(page.getByTestId('restaurant-name')).toHaveText(restaurant.name);
     await expect(page.getByTestId('restaurant-address')).toHaveCount(0);
     await expect(page.getByTestId('book-button')).toBeVisible();
+  });
+
+  test.describe('Booking Flow', () => {
+    async function startBooking(page: import('@playwright/test').Page, slug: string) {
+      await page.goto(`/book/${slug}`);
+      await expect(page.getByTestId('book-button')).toBeVisible();
+      await page.getByTestId('book-button').click();
+      await expect(page.getByRole('heading', { name: 'How many guests?' })).toBeVisible();
+    }
+
+    test('[P0] book → choose party size → pick next open date → time-slot stub shows summary', async ({
+      page,
+      restaurant,
+    }) => {
+      await startBooking(page, restaurant.slug);
+
+      await page.getByTestId('party-size-option-3').click();
+
+      const nextOpenDate = getNextAvailableDate(restaurant.hours);
+      await expect(page.getByTestId(`date-option-${nextOpenDate}`)).toBeVisible();
+      await page.getByTestId(`date-option-${nextOpenDate}`).click();
+
+      const stub = page.getByTestId('time-slot-stub');
+      await expect(stub).toBeVisible();
+      await expect(stub).toContainText('Party size: 3');
+      // The chosen ISO date is exposed machine-readably in the summary.
+      await expect(
+        page.getByTestId('booking-summary').locator('time'),
+      ).toHaveAttribute('datetime', nextOpenDate);
+    });
+
+    test('[P1] back from the calendar preserves the chosen party size', async ({
+      page,
+      restaurant,
+    }) => {
+      await startBooking(page, restaurant.slug);
+
+      await page.getByTestId('party-size-option-4').click();
+      await expect(page.getByTestId('calendar-back')).toBeVisible();
+
+      await page.getByTestId('calendar-back').click();
+
+      const option = page.getByTestId('party-size-option-4');
+      await expect(option).toBeVisible();
+      await expect(option).toHaveClass(/selected/);
+      await expect(option).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    test('[P1] closed weekday is absent from the calendar and navigation still works', async ({
+      page,
+      restaurant,
+    }) => {
+      await startBooking(page, restaurant.slug);
+
+      await page.getByTestId('party-size-option-2').click();
+
+      const closedDay = nextClosedDayIso();
+      await expect(page.getByTestId(`date-option-${closedDay}`)).toHaveCount(0);
+
+      // Month navigation still works alongside hidden days.
+      await page.getByTestId('calendar-next').click();
+      await expect(page.getByTestId('calendar-prev')).toBeEnabled();
+      await page.getByTestId('calendar-prev').click();
+      await expect(page.getByTestId('calendar-prev')).toBeDisabled();
+
+      // Back returns to party size with the selection intact.
+      await page.getByTestId('calendar-back').click();
+      await expect(page.getByTestId('party-size-option-2')).toHaveClass(/selected/);
+    });
   });
 });

--- a/e2e/utils/test-helpers.ts
+++ b/e2e/utils/test-helpers.ts
@@ -39,11 +39,12 @@ export function formatTime(hours: number, minutes: number = 0): string {
 
 /**
  * First open date (per ISO day numbers 1=Mon..7=Sun) on or after "today" in `timezone`,
- * mirroring the app's calendar logic. Returns YYYY-MM-DD.
+ * mirroring the app's calendar logic. Returns YYYY-MM-DD. The timezone is required —
+ * always pass the seeded restaurant's timezone so the helper can never drift from it.
  */
 export function getNextAvailableDate(
   hours: Record<number, { open: string; close: string } | undefined>,
-  timezone: string = 'Europe/London',
+  timezone: string,
 ): string {
   const now = new Date();
   const todayIso = new Intl.DateTimeFormat('en-CA', {

--- a/e2e/utils/test-helpers.ts
+++ b/e2e/utils/test-helpers.ts
@@ -33,33 +33,38 @@ export async function clearAuth(): Promise<void> {
   }
 }
 
-export function formatDate(date: Date): string {
-  return date.toISOString().split('T')[0];
-}
-
 export function formatTime(hours: number, minutes: number = 0): string {
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
 }
 
-export function getNextAvailableDate(hours: Record<number, { open: string; close: string }>): Date {
+/**
+ * First open date (per ISO day numbers 1=Mon..7=Sun) on or after "today" in `timezone`,
+ * mirroring the app's calendar logic. Returns YYYY-MM-DD.
+ */
+export function getNextAvailableDate(
+  hours: Record<number, { open: string; close: string } | undefined>,
+  timezone: string = 'Europe/London',
+): string {
   const now = new Date();
-  let date = new Date(now);
-  
-  while (true) {
-    const dayOfWeek = date.getDay();
-    if (hours[dayOfWeek]) {
-      const [openHour] = hours[dayOfWeek].open.split(':').map(Number);
-      const [closeHour] = hours[dayOfWeek].close.split(':').map(Number);
-      
-      if (date.toDateString() === now.toDateString()) {
-        const currentHour = now.getHours();
-        if (currentHour < closeHour) {
-          return date;
-        }
-      } else {
-        return date;
-      }
+  const todayIso = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now);
+
+  let [year, month, day] = todayIso.split('-').map(Number);
+  for (let i = 0; i < 366; i++) {
+    const iso = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    const utcDayOfWeek = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+    const dayNumber = ((utcDayOfWeek + 6) % 7) + 1;
+    if (hours[dayNumber]) {
+      return iso;
     }
-    date.setDate(date.getDate() + 1);
+    const next = new Date(Date.UTC(year, month - 1, day + 1));
+    year = next.getUTCFullYear();
+    month = next.getUTCMonth() + 1;
+    day = next.getUTCDate();
   }
+  throw new Error('No open day found within the next 366 days');
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,21 @@ process.env.GCLOUD_PROJECT = 'firebase-crackling-fire-4704';
 
 const appBaseUrl = process.env['PLAYWRIGHT_TEST_BASE_URL'] ?? 'http://localhost:4210';
 
+const emulatorServer = {
+  command:
+    'npx firebase emulators:start --only=auth,firestore --project firebase-crackling-fire-4704',
+  port: 9099,
+  reuseExistingServer: true,
+  timeout: 30_000,
+};
+
+const appServer = {
+  command: 'ng serve --configuration e2e',
+  url: appBaseUrl,
+  reuseExistingServer: !process.env['CI'],
+  timeout: 120_000,
+};
+
 export default defineConfig({
   testDir: './e2e/tests',
   globalTeardown: './e2e/global-teardown.ts',
@@ -39,19 +54,10 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: [
-    {
-      command: 'npx firebase emulators:start --only=auth,firestore --project firebase-crackling-fire-4704',
-      port: 9099,
-      reuseExistingServer: true,
-      timeout: 30_000,
-    },
-    {
-      command: 'ng serve --configuration e2e',
-      url: appBaseUrl,
-      reuseExistingServer: !process.env['CI'],
-      timeout: 120_000,
-    },
-  ],
+  // When PLAYWRIGHT_TEST_BASE_URL points at an already-running app, spawning
+  // `ng serve` would hang readiness polling on a URL it will never serve.
+  webServer: process.env['PLAYWRIGHT_TEST_BASE_URL']
+    ? [emulatorServer]
+    : [emulatorServer, appServer],
   outputDir: 'e2e/results',
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,8 @@ process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8081';
 process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099';
 process.env.GCLOUD_PROJECT = 'firebase-crackling-fire-4704';
 
+const appBaseUrl = process.env['PLAYWRIGHT_TEST_BASE_URL'] ?? 'http://localhost:4210';
+
 export default defineConfig({
   testDir: './e2e/tests',
   globalTeardown: './e2e/global-teardown.ts',
@@ -19,7 +21,7 @@ export default defineConfig({
     ['list'],
   ],
   use: {
-    baseURL: process.env['PLAYWRIGHT_TEST_BASE_URL'] ?? 'http://localhost:4210',
+    baseURL: appBaseUrl,
     actionTimeout: 15_000,
     navigationTimeout: 30_000,
     trace: 'retain-on-failure-and-retries',
@@ -46,7 +48,7 @@ export default defineConfig({
     },
     {
       command: 'ng serve --configuration e2e',
-      url: 'http://localhost:4210',
+      url: appBaseUrl,
       reuseExistingServer: !process.env['CI'],
       timeout: 120_000,
     },

--- a/src/booking/pages/booking-page/booking-page.component.html
+++ b/src/booking/pages/booking-page/booking-page.component.html
@@ -74,8 +74,8 @@
           <osef-calendar-step
             class="card step-card"
             data-testid="calendar-step"
-            [hours]="restaurant.value()!.hours"
-            [timezone]="restaurant.value()!.timezone"
+            [hours]="restaurant.value()?.hours ?? {}"
+            [timezone]="restaurant.value()?.timezone || 'UTC'"
             [selected]="flow.selectedDate()"
             (dateSelect)="onDate($event)"
             (back)="flow.back()"

--- a/src/booking/pages/booking-page/booking-page.component.html
+++ b/src/booking/pages/booking-page/booking-page.component.html
@@ -34,18 +34,73 @@
   } @else {
     <h1 class="sr-only">{{ restaurant.value()!.name }} — Book a Table</h1>
     <span class="sr-only" role="status">{{ restaurant.value()!.name }} loaded.</span>
-    <section class="card text-center">
-      <h2 class="text-3xl font-semibold mb-3" data-testid="restaurant-name">
-        {{ restaurant.value()?.name }}
-      </h2>
-      @if (restaurant.value()?.address) {
-        <p class="text-gray-600 mb-6" data-testid="restaurant-address">
-          {{ restaurant.value()?.address }}
-        </p>
+    <p class="sr-only" role="status" aria-live="polite" data-testid="step-announcement">
+      {{ stepAnnouncement() }}
+    </p>
+
+    <div class="step-host">
+      @switch (flow.step()) {
+        @case ('landing') {
+          <section class="card text-center">
+            <h2 class="text-3xl font-semibold mb-3" data-testid="restaurant-name">
+              {{ restaurant.value()?.name }}
+            </h2>
+            @if (restaurant.value()?.address) {
+              <p class="text-gray-600 mb-6" data-testid="restaurant-address">
+                {{ restaurant.value()?.address }}
+              </p>
+            }
+            <button
+              type="button"
+              #bookButton
+              data-testid="book-button"
+              class="button-primary"
+              (click)="flow.start()"
+            >
+              Book a Table
+            </button>
+          </section>
+        }
+        @case ('party-size') {
+          <osef-party-size-step
+            class="card step-card"
+            data-testid="party-size-step"
+            [selected]="flow.partySize()"
+            (partySizeSelect)="onPartySize($event)"
+            (back)="flow.back()"
+          />
+        }
+        @case ('date') {
+          <osef-calendar-step
+            class="card step-card"
+            data-testid="calendar-step"
+            [hours]="restaurant.value()!.hours"
+            [timezone]="restaurant.value()!.timezone"
+            [selected]="flow.selectedDate()"
+            (dateSelect)="onDate($event)"
+            (back)="flow.back()"
+          />
+        }
+        @case ('time') {
+          <section class="card step-card" data-testid="time-slot-stub">
+            <button
+              type="button"
+              class="back-button"
+              data-testid="time-back"
+              aria-label="Back to date selection"
+              (click)="flow.back()"
+            >
+              <span aria-hidden="true">&larr;</span>
+            </button>
+            <h2 #timeHeading tabindex="-1" class="heading">Available times</h2>
+            <p class="summary" data-testid="booking-summary">
+              Party size: {{ flow.partySize() }}<br />
+              <time [attr.datetime]="flow.selectedDate()">{{ selectedDateLabel() }}</time>
+            </p>
+            <p class="muted">Time slots are coming soon — your selections are saved for this visit.</p>
+          </section>
+        }
       }
-      <button type="button" data-testid="book-button" class="button-primary">
-        Book a Table
-      </button>
-    </section>
+    </div>
   }
 </main>

--- a/src/booking/pages/booking-page/booking-page.component.scss
+++ b/src/booking/pages/booking-page/booking-page.component.scss
@@ -45,6 +45,69 @@
   animation: spin 0.8s linear infinite;
 }
 
+.step-host > * {
+  animation: step-in 0.18s ease-out;
+}
+
+.step-card {
+  text-align: left;
+}
+
+.back-button {
+  width: 44px;
+  height: 44px;
+  margin: -8px 0 8px -12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+
+  &:hover {
+    background: #f5f0eb;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--osef-brand-secondary, #8fa67a);
+    outline-offset: 2px;
+  }
+}
+
+.heading {
+  margin: 0 0 16px;
+  font-size: 1.25rem;
+  font-weight: 700;
+  outline: none;
+}
+
+.summary {
+  margin: 0 0 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.6;
+}
+
+.muted {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #6b6b6b;
+}
+
+@keyframes step-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @keyframes spin {
   to {
     transform: rotate(360deg);
@@ -53,6 +116,10 @@
 
 @media (prefers-reduced-motion: reduce) {
   .spinner {
+    animation: none;
+  }
+
+  .step-host > * {
     animation: none;
   }
 }

--- a/src/booking/pages/booking-page/booking-page.component.spec.ts
+++ b/src/booking/pages/booking-page/booking-page.component.spec.ts
@@ -249,6 +249,22 @@ describe('BookingPageComponent', () => {
         fixture.nativeElement.querySelector('[data-testid="step-announcement"]')?.textContent?.trim(),
       ).toBe('Step 2 of 6: Party Size');
     });
+
+    it('[P0] should announce "Step 1 of 6: Start" on landing and again when returning to it', async () => {
+      await createLoadedComponent();
+
+      const announcement = () =>
+        fixture.nativeElement.querySelector('[data-testid="step-announcement"]')?.textContent?.trim();
+      expect(announcement()).toBe('Step 1 of 6: Start');
+
+      bookButton().click();
+      fixture.detectChanges();
+      expect(announcement()).toBe('Step 2 of 6: Party Size');
+
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="party-size-back"]')!.click();
+      fixture.detectChanges();
+      expect(announcement()).toBe('Step 1 of 6: Start');
+    });
   });
 
   describe('FLOW_DATE', () => {
@@ -395,6 +411,38 @@ describe('BookingPageComponent', () => {
         '[data-testid="party-size-option-4"]',
       )!;
       expect(selectedSize.classList.contains('selected')).toBe(true);
+    });
+
+    it('[P1] should reopen the calendar on a future-month selection with its highlight after tapping back on the stub', async () => {
+      await createLoadedComponent(RESTAURANT_OPEN_ALL_WEEK);
+      bookButton().click();
+      fixture.detectChanges();
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="party-size-option-4"]')!.click();
+      fixture.detectChanges();
+
+      // Forward two months: August → October, then pick Fri 2026-10-02.
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-next"]')!.click();
+      fixture.detectChanges();
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-next"]')!.click();
+      fixture.detectChanges();
+      expect(queryEl().textContent).toContain('October 2026');
+      queryEl()
+        .querySelector<HTMLButtonElement>('[data-testid="date-option-2026-10-02"]')!
+        .click();
+      fixture.detectChanges();
+
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="time-back"]')!.click();
+      fixture.detectChanges();
+
+      // The calendar must remount on the selected month — not snap back to August,
+      // where the highlighted date does not exist in the DOM at all.
+      expect(queryEl().textContent).toContain('October 2026');
+      const selected = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="date-option-2026-10-02"]',
+      )!;
+      expect(selected).toBeTruthy();
+      expect(selected.classList.contains('selected')).toBe(true);
+      expect(selected.getAttribute('aria-pressed')).toBe('true');
     });
   });
 

--- a/src/booking/pages/booking-page/booking-page.component.spec.ts
+++ b/src/booking/pages/booking-page/booking-page.component.spec.ts
@@ -36,6 +36,17 @@ const RESTAURANT_OPEN_ALL_WEEK: Restaurant = {
 /** Thursday 2026-08-20 at 23:30 UTC — already Friday Aug 21 in Europe/London. */
 const FIXED_NOW = () => new Date('2026-08-20T23:30:00Z');
 
+/**
+ * Simulates a Firestore doc missing hours/timezone at runtime (both fields are
+ * required by the Restaurant type, so they are stripped post-construction).
+ */
+const BROKEN_RESTAURANT: Restaurant = (() => {
+  const partial = { ...RESTAURANT_OPEN_ALL_WEEK } as Record<string, unknown>;
+  delete partial['hours'];
+  delete partial['timezone'];
+  return partial as unknown as Restaurant;
+})();
+
 describe('BookingPageComponent', () => {
   let fixture: ComponentFixture<BookingPageComponent>;
   let bookingServiceSpy: { getRestaurantBySlug: ReturnType<typeof vi.fn> };
@@ -340,6 +351,21 @@ describe('BookingPageComponent', () => {
       expect(selected.classList.contains('selected')).toBe(true);
       expect(selected.getAttribute('aria-pressed')).toBe('true');
     });
+
+    it('[P0] should render an empty calendar instead of throwing when hours/timezone are missing', async () => {
+      await createLoadedComponent(BROKEN_RESTAURANT);
+
+      bookButton().click();
+      fixture.detectChanges();
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="party-size-option-4"]')!.click();
+      fixture.detectChanges();
+
+      expect(queryEl().querySelector('[data-testid="calendar-step"]')).toBeTruthy();
+      expect(queryEl().querySelectorAll('.date-btn')).toHaveLength(0);
+      expect(
+        queryEl().querySelector('[data-testid="calendar-empty"]')?.textContent?.trim(),
+      ).toBe('No available dates in this month.');
+    });
   });
 
   describe('BACK_PRESERVES', () => {
@@ -388,6 +414,38 @@ describe('BookingPageComponent', () => {
       expect(bookButton()).toBeTruthy();
       expect(fixture.nativeElement.querySelector('[data-testid="party-size-step"]')).toBeFalsy();
       expect(fixture.componentInstance.flow.partySize()).toBeNull();
+    });
+
+    it('[P0] should reset the root-singleton flow when the page is destroyed mid-flow', async () => {
+      await createLoadedComponent(RESTAURANT_OPEN_ALL_WEEK);
+
+      bookButton().click();
+      fixture.detectChanges();
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="party-size-option-4"]')!.click();
+      fixture.detectChanges();
+
+      const flow = fixture.componentInstance.flow;
+      expect(flow.step()).toBe('date');
+      expect(flow.partySize()).toBe(4);
+
+      fixture.destroy();
+
+      expect(flow.step()).toBe('landing');
+      expect(flow.partySize()).toBeNull();
+      expect(flow.selectedDate()).toBeNull();
+
+      // Recreating on the same TestBed shares the root-singleton service —
+      // the revisit must start at landing with no stale selections.
+      bookingServiceSpy.getRestaurantBySlug.mockResolvedValue(RESTAURANT_OPEN_ALL_WEEK);
+      fixture = TestBed.createComponent(BookingPageComponent);
+      fixture.componentRef.setInput('slug', 'the-blue-bistro');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(bookButton()).toBeTruthy();
+      expect(fixture.componentInstance.flow.partySize()).toBeNull();
+      expect(fixture.componentInstance.flow.selectedDate()).toBeNull();
     });
   });
 });

--- a/src/booking/pages/booking-page/booking-page.component.spec.ts
+++ b/src/booking/pages/booking-page/booking-page.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { BookingPageComponent } from './booking-page.component';
 import { BookingService } from '../../services/booking.service';
+import { NOW } from '../../utils/clock';
 import type { Restaurant } from '../../../shared/types/restaurant';
 
 const RESTAURANT_FIXTURE: Restaurant = {
@@ -18,9 +19,30 @@ const RESTAURANT_FIXTURE: Restaurant = {
   createdAt: new Date('2026-01-01T00:00:00Z'),
 };
 
+/** Open every day — combined with the fixed clock (Thu 2026-08-20) the calendar is deterministic. */
+const RESTAURANT_OPEN_ALL_WEEK: Restaurant = {
+  ...RESTAURANT_FIXTURE,
+  hours: {
+    1: { open: '09:00', close: '17:00' },
+    2: { open: '09:00', close: '17:00' },
+    3: { open: '09:00', close: '17:00' },
+    4: { open: '09:00', close: '17:00' },
+    5: { open: '09:00', close: '17:00' },
+    6: { open: '09:00', close: '17:00' },
+    7: { open: '09:00', close: '17:00' },
+  },
+};
+
+/** Thursday 2026-08-20 at 23:30 UTC — already Friday Aug 21 in Europe/London. */
+const FIXED_NOW = () => new Date('2026-08-20T23:30:00Z');
+
 describe('BookingPageComponent', () => {
   let fixture: ComponentFixture<BookingPageComponent>;
   let bookingServiceSpy: { getRestaurantBySlug: ReturnType<typeof vi.fn> };
+
+  function queryEl(): HTMLElement {
+    return fixture.nativeElement as HTMLElement;
+  }
 
   beforeEach(async () => {
     bookingServiceSpy = { getRestaurantBySlug: vi.fn() };
@@ -30,6 +52,7 @@ describe('BookingPageComponent', () => {
       providers: [
         provideRouter([]),
         { provide: BookingService, useValue: bookingServiceSpy },
+        { provide: NOW, useValue: FIXED_NOW },
       ],
     }).compileComponents();
   });
@@ -42,6 +65,16 @@ describe('BookingPageComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+  }
+
+  /** Loads the page with a successfully resolved restaurant, ready for flow interactions. */
+  async function createLoadedComponent(restaurant: Restaurant = RESTAURANT_FIXTURE): Promise<void> {
+    bookingServiceSpy.getRestaurantBySlug.mockResolvedValue(restaurant);
+    await createComponent('the-blue-bistro');
+  }
+
+  function bookButton(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('[data-testid="book-button"]');
   }
 
   describe('HAPPY_PATH', () => {
@@ -68,7 +101,7 @@ describe('BookingPageComponent', () => {
       expect(fixture.nativeElement.querySelector('[data-testid="booking-page-loading"]')).toBeFalsy();
       expect(fixture.nativeElement.querySelector('[data-testid="restaurant-name"]')?.textContent).toContain('The Blue Bistro');
       expect(fixture.nativeElement.querySelector('[data-testid="restaurant-address"]')?.textContent).toContain('42 Rue de Rivoli');
-      expect(fixture.nativeElement.querySelector('[data-testid="book-button"]')?.textContent).toContain('Book a Table');
+      expect(bookButton()?.textContent).toContain('Book a Table');
     });
 
     it('[P1] should apply white-label colors as host CSS custom properties', async () => {
@@ -91,7 +124,7 @@ describe('BookingPageComponent', () => {
 
       expect(fixture.nativeElement.querySelector('[data-testid="restaurant-name"]')?.textContent).toContain('The Blue Bistro');
       expect(fixture.nativeElement.querySelector('[data-testid="restaurant-address"]')).toBeFalsy();
-      expect(fixture.nativeElement.querySelector('[data-testid="book-button"]')).toBeTruthy();
+      expect(bookButton()).toBeTruthy();
     });
   });
 
@@ -101,7 +134,7 @@ describe('BookingPageComponent', () => {
       await createComponent('definitely-not-a-real-slug');
 
       expect(fixture.nativeElement.textContent).toContain('Restaurant not found');
-      expect(fixture.nativeElement.querySelector('[data-testid="book-button"]')).toBeFalsy();
+      expect(bookButton()).toBeFalsy();
       expect(fixture.nativeElement.querySelector('[data-testid="retry-button"]')).toBeFalsy();
     });
   });
@@ -112,7 +145,7 @@ describe('BookingPageComponent', () => {
       await createComponent('stale-slug');
 
       expect(fixture.nativeElement.textContent).toContain('Restaurant not found');
-      expect(fixture.nativeElement.querySelector('[data-testid="book-button"]')).toBeFalsy();
+      expect(bookButton()).toBeFalsy();
     });
   });
 
@@ -139,6 +172,222 @@ describe('BookingPageComponent', () => {
 
       expect(bookingServiceSpy.getRestaurantBySlug).toHaveBeenCalledTimes(2);
       expect(fixture.nativeElement.querySelector('[data-testid="restaurant-name"]')?.textContent).toContain('The Blue Bistro');
+    });
+  });
+
+  describe('FLOW_PARTY_SIZE', () => {
+    it('[P0] should show the party-size grid when Book a Table is tapped', async () => {
+      await createLoadedComponent();
+
+      bookButton().click();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[data-testid="party-size-step"]')).toBeTruthy();
+      expect(fixture.nativeElement.textContent).toContain('How many guests?');
+      for (const size of [1, 2, 3, 4, 5, 6, 7, 8]) {
+        expect(
+          fixture.nativeElement.querySelector(`[data-testid="party-size-option-${size}"]`),
+        ).toBeTruthy();
+      }
+    });
+
+    it('[P0] should return to landing via the party-size back button', async () => {
+      await createLoadedComponent();
+
+      bookButton().click();
+      fixture.detectChanges();
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="party-size-back"]')!.click();
+      fixture.detectChanges();
+
+      expect(bookButton()).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('[data-testid="party-size-step"]')).toBeFalsy();
+    });
+
+    it('[P1] should move focus to the Book a Table button when returning to landing', async () => {
+      await createLoadedComponent();
+
+      bookButton().click();
+      fixture.detectChanges();
+      expect(document.activeElement).not.toBe(bookButton());
+
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="party-size-back"]')!.click();
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(bookButton());
+    });
+
+    it('[P1] should move focus to the party-size heading on transition', async () => {
+      await createLoadedComponent();
+
+      bookButton().click();
+      fixture.detectChanges();
+
+      const heading = queryEl().querySelector<HTMLHeadingElement>(
+        '[data-testid="party-size-step"] h2',
+      )!;
+      expect(document.activeElement).toBe(heading);
+    });
+
+    it('[P1] should announce "Step 2 of 6: Party Size" in the live region', async () => {
+      await createLoadedComponent();
+
+      bookButton().click();
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="step-announcement"]')?.textContent?.trim(),
+      ).toBe('Step 2 of 6: Party Size');
+    });
+  });
+
+  describe('FLOW_DATE', () => {
+    async function reachCalendar(): Promise<void> {
+      await createLoadedComponent(RESTAURANT_OPEN_ALL_WEEK);
+      bookButton().click();
+      fixture.detectChanges();
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="party-size-option-4"]')!.click();
+      fixture.detectChanges();
+    }
+
+    it('[P0] should auto-advance to the calendar after choosing a party size', async () => {
+      await reachCalendar();
+
+      expect(fixture.nativeElement.querySelector('[data-testid="calendar-step"]')).toBeTruthy();
+      // Fixed clock: "today" is Fri 2026-08-21 in Europe/London; open-all-week renders today onward.
+      expect(
+        queryEl().querySelector('[data-testid="date-option-2026-08-21"]'),
+      ).toBeTruthy();
+      expect(
+        queryEl().querySelector('[data-testid="date-option-2026-08-20"]'),
+      ).toBeFalsy();
+    });
+
+    it('[P0] should announce "Step 3 of 6: Date" in the live region', async () => {
+      await reachCalendar();
+
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="step-announcement"]')?.textContent?.trim(),
+      ).toBe('Step 3 of 6: Date');
+    });
+
+    it('[P0] should auto-advance to the time-slot stub showing the selections after picking a date', async () => {
+      await reachCalendar();
+
+      queryEl()
+        .querySelector<HTMLButtonElement>('[data-testid="date-option-2026-08-21"]')!
+        .click();
+      fixture.detectChanges();
+
+      const stub = fixture.nativeElement.querySelector('[data-testid="time-slot-stub"]');
+      expect(stub).toBeTruthy();
+      expect(stub?.textContent).toContain('Party size: 4');
+      expect(stub?.textContent).toContain('21 August 2026');
+    });
+
+    it('[P0] should expose the chosen ISO date on the summary time element', async () => {
+      await reachCalendar();
+
+      queryEl()
+        .querySelector<HTMLButtonElement>('[data-testid="date-option-2026-08-21"]')!
+        .click();
+      fixture.detectChanges();
+
+      const time = queryEl().querySelector<HTMLElement>('[data-testid="booking-summary"] time');
+      expect(time?.getAttribute('datetime')).toBe('2026-08-21');
+    });
+
+    it('[P0] should announce "Step 4 of 6: Time" after picking a date', async () => {
+      await reachCalendar();
+
+      queryEl()
+        .querySelector<HTMLButtonElement>('[data-testid="date-option-2026-08-21"]')!
+        .click();
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="step-announcement"]')?.textContent?.trim(),
+      ).toBe('Step 4 of 6: Time');
+    });
+
+    it('[P1] should move focus to the time-slot heading after picking a date', async () => {
+      await reachCalendar();
+
+      queryEl()
+        .querySelector<HTMLButtonElement>('[data-testid="date-option-2026-08-21"]')!
+        .click();
+      fixture.detectChanges();
+
+      const heading = queryEl().querySelector<HTMLHeadingElement>(
+        '[data-testid="time-slot-stub"] h2',
+      )!;
+      expect(document.activeElement).toBe(heading);
+    });
+
+    it('[P1] should return to the calendar with the chosen date still highlighted when tapping back on the stub', async () => {
+      await reachCalendar();
+
+      queryEl()
+        .querySelector<HTMLButtonElement>('[data-testid="date-option-2026-08-21"]')!
+        .click();
+      fixture.detectChanges();
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="time-back"]')!.click();
+      fixture.detectChanges();
+
+      expect(queryEl().querySelector('[data-testid="calendar-step"]')).toBeTruthy();
+      const selected = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="date-option-2026-08-21"]',
+      )!;
+      expect(selected.classList.contains('selected')).toBe(true);
+      expect(selected.getAttribute('aria-pressed')).toBe('true');
+    });
+  });
+
+  describe('BACK_PRESERVES', () => {
+    it('[P0] should preserve the date returning from the stub and the party size returning from the calendar', async () => {
+      await createLoadedComponent(RESTAURANT_OPEN_ALL_WEEK);
+      bookButton().click();
+      fixture.detectChanges();
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="party-size-option-4"]')!.click();
+      fixture.detectChanges();
+      queryEl()
+        .querySelector<HTMLButtonElement>('[data-testid="date-option-2026-08-21"]')!
+        .click();
+      fixture.detectChanges();
+
+      // Stub → calendar: date still highlighted.
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="time-back"]')!.click();
+      fixture.detectChanges();
+      const selectedDate = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="date-option-2026-08-21"]',
+      )!;
+      expect(selectedDate.classList.contains('selected')).toBe(true);
+
+      // Calendar → party size: number still highlighted.
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-back"]')!.click();
+      fixture.detectChanges();
+      const selectedSize = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="party-size-option-4"]',
+      )!;
+      expect(selectedSize.classList.contains('selected')).toBe(true);
+    });
+  });
+
+  describe('FLOW_RESET', () => {
+    it('[P1] should reset the flow to landing when the restaurant reloads (slug change)', async () => {
+      await createLoadedComponent(RESTAURANT_OPEN_ALL_WEEK);
+
+      bookButton().click();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[data-testid="party-size-step"]')).toBeTruthy();
+
+      fixture.componentRef.setInput('slug', 'another-bistro');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(bookButton()).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('[data-testid="party-size-step"]')).toBeFalsy();
+      expect(fixture.componentInstance.flow.partySize()).toBeNull();
     });
   });
 });

--- a/src/booking/pages/booking-page/booking-page.component.ts
+++ b/src/booking/pages/booking-page/booking-page.component.ts
@@ -63,15 +63,15 @@ export class BookingPageComponent {
     }
   });
 
-  /** Polite announcement for screen readers on every step transition. */
+  /** Polite announcement for screen readers on every step transition, landing included. */
   stepAnnouncement = computed<string>(() => {
-    const announcements: Record<Exclude<BookingFlowStep, 'landing'>, string> = {
+    const announcements: Record<BookingFlowStep, string> = {
+      landing: `Step 1 of ${TOTAL_STEPS}: Start`,
       'party-size': `Step 2 of ${TOTAL_STEPS}: Party Size`,
       date: `Step 3 of ${TOTAL_STEPS}: Date`,
       time: `Step 4 of ${TOTAL_STEPS}: Time`,
     };
-    const step = this.flow.step();
-    return step === 'landing' ? '' : announcements[step];
+    return announcements[this.flow.step()];
   });
 
   /** Human-readable selected date for the time-slot stub summary. */

--- a/src/booking/pages/booking-page/booking-page.component.ts
+++ b/src/booking/pages/booking-page/booking-page.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  DestroyRef,
   ElementRef,
   computed,
   effect,
@@ -10,12 +11,15 @@ import {
 } from '@angular/core';
 import {Title} from '@angular/platform-browser';
 import {BookingService} from '../../services/booking.service';
-import {BookingFlowService} from '../../services/booking-flow.service';
+import {BookingFlowService, type BookingFlowStep} from '../../services/booking-flow.service';
 import {CalendarStepComponent} from '../../steps/calendar-step/calendar-step.component';
 import {PartySizeStepComponent} from '../../steps/party-size-step/party-size-step.component';
 
 const DESIGN_PRIMARY = '#1A1A1A';
 const DESIGN_SECONDARY = '#8FA67A';
+
+/** Steps in the funnel including landing and the future submit step. */
+const TOTAL_STEPS = 6;
 
 @Component({
   selector: 'osef-booking-page',
@@ -61,12 +65,13 @@ export class BookingPageComponent {
 
   /** Polite announcement for screen readers on every step transition. */
   stepAnnouncement = computed<string>(() => {
-    const announcements: Record<string, string> = {
-      'party-size': 'Step 2 of 6: Party Size',
-      date: 'Step 3 of 6: Date',
-      time: 'Step 4 of 6: Time',
+    const announcements: Record<Exclude<BookingFlowStep, 'landing'>, string> = {
+      'party-size': `Step 2 of ${TOTAL_STEPS}: Party Size`,
+      date: `Step 3 of ${TOTAL_STEPS}: Date`,
+      time: `Step 4 of ${TOTAL_STEPS}: Time`,
     };
-    return announcements[this.flow.step()] ?? '';
+    const step = this.flow.step();
+    return step === 'landing' ? '' : announcements[step];
   });
 
   /** Human-readable selected date for the time-slot stub summary. */
@@ -88,6 +93,10 @@ export class BookingPageComponent {
   private readonly bookButton = viewChild<ElementRef<HTMLButtonElement>>('bookButton');
 
   constructor() {
+    // The flow service is a root singleton that outlives this page — clear any
+    // half-finished funnel when the user leaves, so a same-slug revisit starts fresh.
+    inject(DestroyRef).onDestroy(() => this.flow.reset());
+
     effect(() => {
       try {
         const restaurant = this.restaurant.value();

--- a/src/booking/pages/booking-page/booking-page.component.ts
+++ b/src/booking/pages/booking-page/booking-page.component.ts
@@ -1,6 +1,18 @@
-import {Component, computed, effect, inject, input, resource} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  computed,
+  effect,
+  inject,
+  input,
+  resource,
+  viewChild,
+} from '@angular/core';
 import {Title} from '@angular/platform-browser';
 import {BookingService} from '../../services/booking.service';
+import {BookingFlowService} from '../../services/booking-flow.service';
+import {CalendarStepComponent} from '../../steps/calendar-step/calendar-step.component';
+import {PartySizeStepComponent} from '../../steps/party-size-step/party-size-step.component';
 
 const DESIGN_PRIMARY = '#1A1A1A';
 const DESIGN_SECONDARY = '#8FA67A';
@@ -11,7 +23,7 @@ const DESIGN_SECONDARY = '#8FA67A';
     '[style.--osef-brand-primary]': 'brandPrimary()',
     '[style.--osef-brand-secondary]': 'brandSecondary()',
   },
-  imports: [],
+  imports: [PartySizeStepComponent, CalendarStepComponent],
   templateUrl: './booking-page.component.html',
   styleUrl: './booking-page.component.scss',
 })
@@ -19,6 +31,8 @@ export class BookingPageComponent {
   private bookingService = inject(BookingService);
 
   private title = inject(Title);
+
+  readonly flow = inject(BookingFlowService);
 
   slug = input<string>();
 
@@ -45,6 +59,34 @@ export class BookingPageComponent {
     }
   });
 
+  /** Polite announcement for screen readers on every step transition. */
+  stepAnnouncement = computed<string>(() => {
+    const announcements: Record<string, string> = {
+      'party-size': 'Step 2 of 6: Party Size',
+      date: 'Step 3 of 6: Date',
+      time: 'Step 4 of 6: Time',
+    };
+    return announcements[this.flow.step()] ?? '';
+  });
+
+  /** Human-readable selected date for the time-slot stub summary. */
+  selectedDateLabel = computed<string>(() => {
+    const iso = this.flow.selectedDate();
+    if (!iso) return '';
+    const [year, month, day] = iso.split('-').map(Number);
+    return new Intl.DateTimeFormat('en-GB', {
+      timeZone: 'UTC',
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    }).format(new Date(Date.UTC(year, month - 1, day)));
+  });
+
+  private readonly timeHeading = viewChild<ElementRef<HTMLHeadingElement>>('timeHeading');
+
+  private readonly bookButton = viewChild<ElementRef<HTMLButtonElement>>('bookButton');
+
   constructor() {
     effect(() => {
       try {
@@ -54,6 +96,50 @@ export class BookingPageComponent {
         this.title.setTitle('Booking');
       }
     });
+
+    // A fresh restaurant (initial load, retry, or slug change) resets the flow.
+    effect(() => {
+      try {
+        this.restaurant.value();
+      } catch {
+        // Error state — nothing to reset against; the error UI takes over.
+      }
+      this.flow.reset();
+    });
+
+    // Focus the time-slot stub heading whenever that step mounts.
+    effect(() => {
+      const heading = this.timeHeading();
+      if (heading && this.flow.step() === 'time') {
+        heading.nativeElement.focus();
+      }
+    });
+
+    // Returning to landing from a later step moves focus to the primary CTA.
+    // Latched so initial page load never steals focus, and so the focus retries
+    // until the button actually exists (the switch renders one tick later).
+    let hasEnteredFlow = false;
+    let landingFocusApplied = false;
+    effect(() => {
+      const step = this.flow.step();
+      if (step !== 'landing') {
+        hasEnteredFlow = true;
+        landingFocusApplied = false;
+      }
+      const button = this.bookButton();
+      if (step === 'landing' && hasEnteredFlow && !landingFocusApplied && button) {
+        button.nativeElement.focus();
+        landingFocusApplied = true;
+      }
+    });
+  }
+
+  onPartySize(size: number): void {
+    this.flow.choosePartySize(size);
+  }
+
+  onDate(iso: string): void {
+    this.flow.chooseDate(iso);
   }
 
   retry(): void {

--- a/src/booking/services/booking-flow.service.spec.ts
+++ b/src/booking/services/booking-flow.service.spec.ts
@@ -63,6 +63,21 @@ describe('BookingFlowService', () => {
       service.choosePartySize(2);
       expect(service.partySize()).toBe(2);
       expect(service.step()).toBe('date');
+
+      // Pick a date, then revise the guest count via two backs — the chosen
+      // date must survive (revising party size never erases selections).
+      service.chooseDate('2026-08-21');
+      expect(service.selectedDate()).toBe('2026-08-21');
+      expect(service.step()).toBe('time');
+
+      service.back();
+      service.back();
+      expect(service.step()).toBe('party-size');
+
+      service.choosePartySize(6);
+      expect(service.partySize()).toBe(6);
+      expect(service.step()).toBe('date');
+      expect(service.selectedDate()).toBe('2026-08-21');
     });
 
     it('[P1] should be a no-op on landing', () => {

--- a/src/booking/services/booking-flow.service.spec.ts
+++ b/src/booking/services/booking-flow.service.spec.ts
@@ -1,0 +1,88 @@
+import { describe, beforeEach, it, expect } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { BookingFlowService } from './booking-flow.service';
+
+describe('BookingFlowService', () => {
+  let service: BookingFlowService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BookingFlowService);
+  });
+
+  describe('HAPPY_PATH', () => {
+    it('[P0] should walk landing → party-size → date → time via the actions', () => {
+      expect(service.step()).toBe('landing');
+
+      service.start();
+      expect(service.step()).toBe('party-size');
+
+      service.choosePartySize(4);
+      expect(service.partySize()).toBe(4);
+      expect(service.step()).toBe('date');
+
+      service.chooseDate('2026-08-21');
+      expect(service.selectedDate()).toBe('2026-08-21');
+      expect(service.step()).toBe('time');
+    });
+  });
+
+  describe('BACK_PRESERVES', () => {
+    it('[P0] should return from date to party-size keeping the chosen size', () => {
+      service.start();
+      service.choosePartySize(4);
+      service.back();
+
+      expect(service.step()).toBe('party-size');
+      expect(service.partySize()).toBe(4);
+    });
+
+    it('[P0] should return from time to date keeping the chosen date', () => {
+      service.chooseDate('2026-08-21');
+      service.back();
+
+      expect(service.step()).toBe('date');
+      expect(service.selectedDate()).toBe('2026-08-21');
+    });
+
+    it('[P1] should return from party-size to landing', () => {
+      service.start();
+      service.back();
+
+      expect(service.step()).toBe('landing');
+    });
+
+    it('[P1] should update the size and re-advance to the date step when choosing a different size after back', () => {
+      service.start();
+      service.choosePartySize(4);
+      expect(service.partySize()).toBe(4);
+
+      service.back();
+      expect(service.step()).toBe('party-size');
+
+      service.choosePartySize(2);
+      expect(service.partySize()).toBe(2);
+      expect(service.step()).toBe('date');
+    });
+
+    it('[P1] should be a no-op on landing', () => {
+      service.back();
+
+      expect(service.step()).toBe('landing');
+    });
+  });
+
+  describe('RESET', () => {
+    it('[P0] should clear step and selections back to landing', () => {
+      service.start();
+      service.choosePartySize(4);
+      service.chooseDate('2026-08-21');
+
+      service.reset();
+
+      expect(service.step()).toBe('landing');
+      expect(service.partySize()).toBeNull();
+      expect(service.selectedDate()).toBeNull();
+    });
+  });
+});

--- a/src/booking/services/booking-flow.service.ts
+++ b/src/booking/services/booking-flow.service.ts
@@ -1,0 +1,52 @@
+import { Service, signal } from '@angular/core';
+
+export type BookingFlowStep = 'landing' | 'party-size' | 'date' | 'time';
+
+/**
+ * Signal-driven state machine for the booking flow (Stories 2.2–2.5).
+ * Selections are ephemeral until final submit — no URL/guard plumbing.
+ */
+@Service()
+export class BookingFlowService {
+  readonly step = signal<BookingFlowStep>('landing');
+  readonly partySize = signal<number | null>(null);
+  readonly selectedDate = signal<string | null>(null);
+
+  /** Landing → party size. */
+  start(): void {
+    this.step.set('party-size');
+  }
+
+  /** Party size selected → auto-advance to the calendar. Selections are never deselected. */
+  choosePartySize(size: number): void {
+    this.partySize.set(size);
+    this.step.set('date');
+  }
+
+  /** Date selected → auto-advance to the time-slot step. */
+  chooseDate(iso: string): void {
+    this.selectedDate.set(iso);
+    this.step.set('time');
+  }
+
+  /**
+   * One step back, preserving all selections (BACK_PRESERVES).
+   * No-op on landing.
+   */
+  back(): void {
+    const previous: Partial<Record<BookingFlowStep, BookingFlowStep>> = {
+      'party-size': 'landing',
+      date: 'party-size',
+      time: 'date',
+    };
+    const target = previous[this.step()];
+    if (target) this.step.set(target);
+  }
+
+  /** Clears the whole flow — called when the restaurant is (re)loaded. */
+  reset(): void {
+    this.step.set('landing');
+    this.partySize.set(null);
+    this.selectedDate.set(null);
+  }
+}

--- a/src/booking/steps/calendar-step/calendar-step.component.html
+++ b/src/booking/steps/calendar-step/calendar-step.component.html
@@ -1,0 +1,61 @@
+<div class="step">
+  <button
+    type="button"
+    class="back-button"
+    data-testid="calendar-back"
+    aria-label="Back to party size"
+    (click)="back.emit()"
+  >
+    <span aria-hidden="true">&larr;</span>
+  </button>
+
+  <h2 #heading tabindex="-1" class="heading">Pick a date</h2>
+
+  <div class="month-nav">
+    <button
+      type="button"
+      class="nav-button"
+      data-testid="calendar-prev"
+      aria-label="Previous month"
+      [disabled]="monthOffset() === 0"
+      (click)="prev()"
+    >
+      <span aria-hidden="true">&lsaquo;</span>
+    </button>
+    <span class="month-label">{{ monthLabel() }}</span>
+    <button
+      type="button"
+      class="nav-button"
+      data-testid="calendar-next"
+      aria-label="Next month"
+      (click)="next()"
+    >
+      <span aria-hidden="true">&rsaquo;</span>
+    </button>
+  </div>
+
+  @if (cells().length > 0) {
+    <div class="weekdays" aria-hidden="true">
+      @for (day of weekdays; track day) {
+        <span>{{ day }}</span>
+      }
+    </div>
+    <div class="grid" role="group" aria-label="Available dates">
+      @for (cell of cells(); track cell.iso) {
+        <button
+          type="button"
+          class="date-btn"
+          [class.selected]="selected() === cell.iso"
+          [attr.aria-pressed]="selected() === cell.iso"
+          [attr.aria-label]="dateLabel(cell.iso)"
+          [attr.data-testid]="'date-option-' + cell.iso"
+          (click)="choose(cell.iso)"
+        >
+          {{ dayOfMonth(cell.iso) }}
+        </button>
+      }
+    </div>
+  } @else {
+    <p class="empty-month" data-testid="calendar-empty">No available dates in this month.</p>
+  }
+</div>

--- a/src/booking/steps/calendar-step/calendar-step.component.html
+++ b/src/booking/steps/calendar-step/calendar-step.component.html
@@ -41,12 +41,17 @@
       }
     </div>
     <div class="grid" role="group" aria-label="Available dates">
+      @for (spacer of leadingSpacers(); track $index) {
+        <span aria-hidden="true" class="spacer"></span>
+      }
       @for (cell of cells(); track cell.iso) {
         <button
           type="button"
           class="date-btn"
           [class.selected]="selected() === cell.iso"
+          [class.today]="cell.iso === today().iso"
           [attr.aria-pressed]="selected() === cell.iso"
+          [attr.aria-current]="cell.iso === today().iso ? 'date' : null"
           [attr.aria-label]="dateLabel(cell.iso)"
           [attr.data-testid]="'date-option-' + cell.iso"
           (click)="choose(cell.iso)"

--- a/src/booking/steps/calendar-step/calendar-step.component.scss
+++ b/src/booking/steps/calendar-step/calendar-step.component.scss
@@ -1,0 +1,138 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+.step {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  text-align: left;
+}
+
+.back-button {
+  align-self: flex-start;
+  width: 44px;
+  height: 44px;
+  margin: -8px 0 8px -12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+
+  &:hover {
+    background: #f5f0eb;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--osef-brand-secondary, #8fa67a);
+    outline-offset: 2px;
+  }
+}
+
+.heading {
+  margin: 0 0 16px;
+  font-size: 1.25rem;
+  font-weight: 700;
+  outline: none;
+}
+
+.month-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.month-label {
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.nav-button {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #e5e0db;
+  border-radius: 8px;
+  background: #ffffff;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    border-color: #6b6b6b;
+  }
+
+  &:disabled {
+    opacity: 0.35;
+    cursor: default;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--osef-brand-secondary, #8fa67a);
+    outline-offset: 2px;
+  }
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+}
+
+.weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+  margin-bottom: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #6b6b6b;
+  text-align: center;
+
+  span {
+    padding: 4px 0;
+  }
+}
+
+.empty-month {
+  margin: 16px 0;
+  font-size: 0.9375rem;
+  color: #6b6b6b;
+}
+
+.date-btn {
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 8px;
+  border: 2px solid #e5e0db;
+  background: #ffffff;
+  color: inherit;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover:not(.selected) {
+    border-color: #6b6b6b;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--osef-brand-secondary, #8fa67a);
+    outline-offset: 2px;
+  }
+
+  &.selected {
+    background: var(--osef-brand-primary, #1a1a1a);
+    border-color: var(--osef-brand-primary, #1a1a1a);
+    color: #ffffff;
+  }
+}

--- a/src/booking/steps/calendar-step/calendar-step.component.scss
+++ b/src/booking/steps/calendar-step/calendar-step.component.scss
@@ -130,6 +130,11 @@
     outline-offset: 2px;
   }
 
+  &.today:not(.selected) {
+    border-color: var(--osef-brand-secondary, #8fa67a);
+    font-weight: 700;
+  }
+
   &.selected {
     background: var(--osef-brand-primary, #1a1a1a);
     border-color: var(--osef-brand-primary, #1a1a1a);

--- a/src/booking/steps/calendar-step/calendar-step.component.spec.ts
+++ b/src/booking/steps/calendar-step/calendar-step.component.spec.ts
@@ -83,6 +83,28 @@ describe('CalendarStepComponent', () => {
     });
   });
 
+  describe('GRID_ALIGNMENT', () => {
+    it('[P0] should place the first selectable date under its weekday header via leading spacers', async () => {
+      await createComponent();
+
+      // First open day is Fri 2026-08-21 (ISO day 5) → four placeholder columns before it.
+      expect(queryEl().querySelectorAll('.grid .spacer')).toHaveLength(4);
+    });
+
+    it('[P1] should realign spacers when navigating to a month starting midweek', async () => {
+      await createComponent();
+
+      // September 2026 starts on a Tuesday (ISO day 2) → one spacer.
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-next"]')!.click();
+      fixture.detectChanges();
+
+      expect(queryEl().querySelectorAll('.grid .spacer')).toHaveLength(1);
+      expect(
+        queryEl().querySelector('.grid .date-btn')?.getAttribute('data-testid'),
+      ).toBe('date-option-2026-09-01');
+    });
+  });
+
   describe('DAY_HIDDEN', () => {
     it('[P0] should omit past-but-open days entirely', async () => {
       await createComponent();
@@ -213,6 +235,37 @@ describe('CalendarStepComponent', () => {
       expect(selected.getAttribute('aria-pressed')).toBe('true');
       expect(unselected.classList.contains('selected')).toBe(false);
     });
+
+    it('[P0] should open on the selected month when the selection lies beyond the current month', async () => {
+      // Returning from a later step remounts this component; the view must anchor
+      // to October (the selection's month), not snap back to August.
+      await createComponent({ selected: '2026-10-02' });
+
+      expect(queryEl().textContent).toContain('October 2026');
+      const selected = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="date-option-2026-10-02"]',
+      )!;
+      expect(selected.classList.contains('selected')).toBe(true);
+      expect(selected.getAttribute('aria-pressed')).toBe('true');
+    });
+  });
+
+  describe('TODAY_MARKER', () => {
+    it('[P1] should mark today with a visual treatment and aria-current="date"', async () => {
+      await createComponent();
+
+      const todayCell = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="date-option-2026-08-21"]',
+      )!;
+      const otherCell = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="date-option-2026-08-25"]',
+      )!;
+
+      expect(todayCell.classList.contains('today')).toBe(true);
+      expect(todayCell.getAttribute('aria-current')).toBe('date');
+      expect(otherCell.classList.contains('today')).toBe(false);
+      expect(otherCell.getAttribute('aria-current')).toBeNull();
+    });
   });
 
   describe('BACK_NAVIGATION', () => {
@@ -256,6 +309,30 @@ describe('CalendarStepComponent', () => {
       ).toBeFalsy();
       expect(
         fixture.nativeElement.querySelector('[data-testid="date-option-2026-08-21"]'),
+      ).toBeTruthy();
+    });
+
+    it('[P1] should refresh "today" when navigating months after midnight passes', async () => {
+      let instant = new Date('2026-08-20T23:30:00Z');
+      await createComponent({ now: () => instant });
+
+      // Fri Aug 21 is selectable before London midnight passes.
+      expect(
+        queryEl().querySelector('[data-testid="date-option-2026-08-21"]'),
+      ).toBeTruthy();
+
+      instant = new Date('2026-08-21T23:30:00Z'); // already Sat Aug 22 in Europe/London
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-next"]')!.click();
+      fixture.detectChanges();
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-prev"]')!.click();
+      fixture.detectChanges();
+
+      // Today is now Sat Aug 22 — Aug 21 dropped as a past day.
+      expect(
+        queryEl().querySelector('[data-testid="date-option-2026-08-21"]'),
+      ).toBeFalsy();
+      expect(
+        queryEl().querySelector('[data-testid="date-option-2026-08-22"]'),
       ).toBeTruthy();
     });
   });

--- a/src/booking/steps/calendar-step/calendar-step.component.spec.ts
+++ b/src/booking/steps/calendar-step/calendar-step.component.spec.ts
@@ -28,11 +28,12 @@ describe('CalendarStepComponent', () => {
       selected?: string | null;
       timezone?: string;
       hours?: OpeningHours;
+      now?: () => Date;
     } = {},
   ): Promise<void> {
     await TestBed.configureTestingModule({
       imports: [CalendarStepComponent],
-      providers: [{ provide: NOW, useValue: FIXED_NOW }],
+      providers: [{ provide: NOW, useValue: overrides.now ?? FIXED_NOW }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CalendarStepComponent);
@@ -142,6 +143,31 @@ describe('CalendarStepComponent', () => {
       expect(rendered[0]).toBe('date-option-2026-09-01');
       expect(rendered).not.toContain('date-option-2026-09-07');
       expect(rendered.at(-1)).toBe('date-option-2026-09-30');
+    });
+
+    it('[P0] YEAR_BOUNDARY: should roll navigation from December 2026 into January 2027', async () => {
+      await createComponent({ now: () => new Date('2026-12-28T12:00:00Z') });
+
+      expect(queryEl().textContent).toContain('December 2026');
+
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-next"]')!.click();
+      fixture.detectChanges();
+
+      expect(queryEl().textContent).toContain('January 2027');
+
+      const rendered = [
+        ...queryEl().querySelectorAll<HTMLButtonElement>('.date-btn'),
+      ].map((b) => b.getAttribute('data-testid'));
+
+      // Jan 1 2027 is a Friday — first cell, correctly placed in the week.
+      expect(rendered[0]).toBe('date-option-2027-01-01');
+      // Mondays (4, 11, 18, 25) hidden as closed across the new year.
+      expect(rendered).not.toContain('date-option-2027-01-04');
+      expect(rendered).not.toContain('date-option-2027-01-11');
+      expect(rendered).not.toContain('date-option-2027-01-18');
+      expect(rendered).not.toContain('date-option-2027-01-25');
+      // Jan 31 2027 is a Sunday (open) — the grid reaches the true end of month.
+      expect(rendered.at(-1)).toBe('date-option-2027-01-31');
     });
   });
 

--- a/src/booking/steps/calendar-step/calendar-step.component.spec.ts
+++ b/src/booking/steps/calendar-step/calendar-step.component.spec.ts
@@ -1,0 +1,236 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CalendarStepComponent } from './calendar-step.component';
+import { NOW } from '../../utils/clock';
+import type { OpeningHours } from '../../../shared/types/restaurant';
+
+/** Open every day except Monday (ISO day 1). */
+const HOURS_CLOSED_MONDAY: OpeningHours = {
+  2: { open: '09:00', close: '17:00' },
+  3: { open: '09:00', close: '17:00' },
+  4: { open: '09:00', close: '17:00' },
+  5: { open: '09:00', close: '17:00' },
+  6: { open: '09:00', close: '17:00' },
+  7: { open: '09:00', close: '17:00' },
+};
+
+/** Thursday 2026-08-20 at 23:30 UTC — already Friday Aug 21 in London, still Aug 20 in New York. */
+const FIXED_NOW = () => new Date('2026-08-20T23:30:00Z');
+
+describe('CalendarStepComponent', () => {
+  let fixture: ComponentFixture<CalendarStepComponent>;
+
+  function queryEl(): HTMLElement {
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  async function createComponent(
+    overrides: {
+      selected?: string | null;
+      timezone?: string;
+      hours?: OpeningHours;
+    } = {},
+  ): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [CalendarStepComponent],
+      providers: [{ provide: NOW, useValue: FIXED_NOW }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CalendarStepComponent);
+    fixture.componentRef.setInput('hours', overrides.hours ?? HOURS_CLOSED_MONDAY);
+    fixture.componentRef.setInput('timezone', overrides.timezone ?? 'Europe/London');
+    fixture.componentRef.setInput('selected', overrides.selected ?? null);
+    fixture.detectChanges();
+  }
+
+  describe('HAPPY_PATH', () => {
+    it('[P0] should render the heading, month label, and only open dates from today onward', async () => {
+      await createComponent();
+
+      const el = fixture.nativeElement as HTMLElement;
+      expect(el.querySelector('h2')?.textContent).toContain('Pick a date');
+      expect(el.textContent).toContain('August 2026');
+
+      // "Today" is Fri 2026-08-21 in Europe/London; Mondays (17, 24, 31) hidden as closed.
+      const rendered = [...el.querySelectorAll<HTMLButtonElement>('.date-btn')].map(
+        (b) => b.getAttribute('data-testid'),
+      );
+      expect(rendered).toEqual([
+        'date-option-2026-08-21',
+        'date-option-2026-08-22',
+        'date-option-2026-08-23',
+        'date-option-2026-08-25',
+        'date-option-2026-08-26',
+        'date-option-2026-08-27',
+        'date-option-2026-08-28',
+        'date-option-2026-08-29',
+        'date-option-2026-08-30',
+      ]);
+    });
+
+    it('[P0] should emit the ISO date when an open date is tapped', async () => {
+      await createComponent();
+
+      const emitted: string[] = [];
+      fixture.componentInstance.dateSelect.subscribe((iso) => emitted.push(iso));
+
+      queryEl()
+        .querySelector<HTMLButtonElement>('[data-testid="date-option-2026-08-21"]')!
+        .click();
+      fixture.detectChanges();
+
+      expect(emitted).toEqual(['2026-08-21']);
+    });
+  });
+
+  describe('DAY_HIDDEN', () => {
+    it('[P0] should omit past-but-open days entirely', async () => {
+      await createComponent();
+
+      // Wednesday 2026-08-19 is open but before today (2026-08-21 in London).
+      expect(
+        queryEl().querySelector('[data-testid="date-option-2026-08-19"]'),
+      ).toBeFalsy();
+    });
+
+    it('[P0] should omit closed weekdays entirely, including future ones', async () => {
+      await createComponent();
+
+      // Monday 2026-08-24 is in the future but closed.
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="date-option-2026-08-24"]'),
+      ).toBeFalsy();
+    });
+  });
+
+  describe('MONTH_NAV', () => {
+    it('[P0] should disable prev on the current month and enable it after navigating forward', async () => {
+      await createComponent();
+
+      const prev = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="calendar-prev"]',
+      )!;
+      const next = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="calendar-next"]',
+      )!;
+
+      expect(prev.disabled).toBe(true);
+
+      next.click();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('September 2026');
+      expect(prev.disabled).toBe(false);
+
+      prev.click();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('August 2026');
+      expect(prev.disabled).toBe(true);
+    });
+
+    it('[P1] should rebuild the grid for the viewed month', async () => {
+      await createComponent();
+
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-next"]')!.click();
+      fixture.detectChanges();
+
+      const rendered = [
+        ...queryEl().querySelectorAll<HTMLButtonElement>('.date-btn'),
+      ].map((b) => b.getAttribute('data-testid'));
+
+      // September 2026: Sep 1 is a Tuesday; Mondays (7, 14, 21, 28) hidden.
+      expect(rendered[0]).toBe('date-option-2026-09-01');
+      expect(rendered).not.toContain('date-option-2026-09-07');
+      expect(rendered.at(-1)).toBe('date-option-2026-09-30');
+    });
+  });
+
+  describe('EMPTY_MONTH', () => {
+    it('[P1] should show the empty-state message when the viewed month has zero selectable dates', async () => {
+      await createComponent({ hours: {} });
+
+      expect(queryEl().querySelectorAll('.date-btn')).toHaveLength(0);
+      const empty = queryEl().querySelector('[data-testid="calendar-empty"]');
+      expect(empty?.textContent?.trim()).toBe('No available dates in this month.');
+    });
+
+    it('[P1] should keep forward navigation unbounded while a month is empty', async () => {
+      await createComponent({ hours: {} });
+
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-next"]')!.click();
+      fixture.detectChanges();
+
+      expect(
+        queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-prev"]')!.disabled,
+      ).toBe(false);
+
+      // No cap: stepping forward again renders another (empty) month just fine.
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-next"]')!.click();
+      fixture.detectChanges();
+
+      expect(queryEl().querySelector('[data-testid="calendar-empty"]')).toBeTruthy();
+    });
+  });
+
+  describe('SELECTION_STATE', () => {
+    it('[P1] should highlight the selected date when returning via back navigation', async () => {
+      await createComponent({ selected: '2026-08-21' });
+
+      const selected = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="date-option-2026-08-21"]',
+      )!;
+      const unselected = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="date-option-2026-08-22"]',
+      )!;
+
+      expect(selected.classList.contains('selected')).toBe(true);
+      expect(selected.getAttribute('aria-pressed')).toBe('true');
+      expect(unselected.classList.contains('selected')).toBe(false);
+    });
+  });
+
+  describe('BACK_NAVIGATION', () => {
+    it('[P1] should emit back when the back button is tapped', async () => {
+      await createComponent();
+
+      let backCount = 0;
+      fixture.componentInstance.back.subscribe(() => backCount++);
+
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="calendar-back"]')!.click();
+      fixture.detectChanges();
+
+      expect(backCount).toBe(1);
+    });
+  });
+
+  describe('FOCUS_MANAGEMENT', () => {
+    it('[P0] should move focus to the step heading on init', async () => {
+      await createComponent();
+
+      const heading = queryEl().querySelector<HTMLHeadingElement>('h2')!;
+      expect(document.activeElement).toBe(heading);
+      expect(heading.getAttribute('tabindex')).toBe('-1');
+    });
+  });
+
+  describe('TZ_BOUNDARY', () => {
+    it('[P1] should derive "today" from the restaurant timezone, not the device clock', async () => {
+      // 2026-08-20T23:30Z is already Fri Aug 21 in London but still Thu Aug 20 in New York.
+      await createComponent({ timezone: 'America/New_York' });
+
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="date-option-2026-08-20"]'),
+      ).toBeTruthy();
+
+      fixture.componentRef.setInput('timezone', 'Europe/London');
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="date-option-2026-08-20"]'),
+      ).toBeFalsy();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="date-option-2026-08-21"]'),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/src/booking/steps/calendar-step/calendar-step.component.ts
+++ b/src/booking/steps/calendar-step/calendar-step.component.ts
@@ -29,13 +29,42 @@ export class CalendarStepComponent implements AfterViewInit {
   private readonly now = inject(NOW);
   private readonly heading = viewChild.required<ElementRef<HTMLHeadingElement>>('heading');
 
-  /** 0 = current month (in the restaurant timezone); prev is disabled there. */
-  readonly monthOffset = signal(0);
+  /** Bumped on month navigation so "today" is re-derived after long idle periods. */
+  private readonly navTick = signal(0);
 
   /** Sighted-only weekday context above the grid (aria-hidden in the template). */
   readonly weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
 
-  private readonly today = computed(() => zonedToday(this.timezone(), this.now()));
+  /**
+   * Today in the restaurant timezone. Re-derived whenever the timezone changes
+   * or the user navigates months — a tab parked across midnight catches up at
+   * the next navigation instead of keeping yesterday selectable forever.
+   */
+  readonly today = computed(() => {
+    this.navTick();
+    return zonedToday(this.timezone(), this.now());
+  });
+
+  /** Month offset implied by the selected date, or null when nothing is selected yet. */
+  private readonly selectedMonthOffset = computed<number | null>(() => {
+    const selected = this.selected();
+    if (!selected) return null;
+    const [todayYear, todayMonth] = this.today().iso.split('-').map(Number);
+    const [selectedYear, selectedMonth] = selected.split('-').map(Number);
+    return (selectedYear - todayYear) * 12 + (selectedMonth - todayMonth);
+  });
+
+  /** Explicit user navigation; null until prev/next is clicked. */
+  private readonly userMonthOffset = signal<number | null>(null);
+
+  /**
+   * Effective month offset from the current month (0 = current). Before the
+   * user navigates, a selection beyond the current month anchors the view to
+   * its own month so back-navigation keeps the highlighted date visible.
+   */
+  readonly monthOffset = computed(() =>
+    Math.max(0, this.userMonthOffset() ?? this.selectedMonthOffset() ?? 0),
+  );
 
   private readonly view = computed(() => {
     const [year, month] = this.today().iso.split('-').map(Number);
@@ -54,16 +83,28 @@ export class CalendarStepComponent implements AfterViewInit {
     buildMonthGrid(this.view().year, this.view().month, this.hours(), this.today().iso),
   );
 
+  /**
+   * Non-interactive placeholders keeping the first date under its weekday
+   * header — closed/past days are omitted from the grid, so without these the
+   * remaining buttons pack flush-left and drift under the wrong labels.
+   */
+  readonly leadingSpacers = computed(() => {
+    const firstDay = this.cells()[0]?.dayNumber ?? 1;
+    return Array.from({length: Math.max(0, firstDay - 1)});
+  });
+
   ngAfterViewInit(): void {
     this.heading().nativeElement.focus();
   }
 
   prev(): void {
-    this.monthOffset.update((offset) => Math.max(0, offset - 1));
+    this.userMonthOffset.set(Math.max(0, this.monthOffset() - 1));
+    this.navTick.update((tick) => tick + 1);
   }
 
   next(): void {
-    this.monthOffset.update((offset) => offset + 1);
+    this.userMonthOffset.set(this.monthOffset() + 1);
+    this.navTick.update((tick) => tick + 1);
   }
 
   choose(iso: string): void {

--- a/src/booking/steps/calendar-step/calendar-step.component.ts
+++ b/src/booking/steps/calendar-step/calendar-step.component.ts
@@ -1,0 +1,87 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
+import type { OpeningHours } from '../../../shared/types/restaurant';
+import { buildMonthGrid, zonedToday } from '../../utils/calendar';
+import { NOW } from '../../utils/clock';
+
+@Component({
+  selector: 'osef-calendar-step',
+  templateUrl: './calendar-step.component.html',
+  styleUrl: './calendar-step.component.scss',
+})
+export class CalendarStepComponent implements AfterViewInit {
+  readonly hours = input.required<OpeningHours>();
+  readonly timezone = input.required<string>();
+  readonly selected = input<string | null>(null);
+
+  readonly dateSelect = output<string>();
+  readonly back = output<void>();
+
+  private readonly now = inject(NOW);
+  private readonly heading = viewChild.required<ElementRef<HTMLHeadingElement>>('heading');
+
+  /** 0 = current month (in the restaurant timezone); prev is disabled there. */
+  readonly monthOffset = signal(0);
+
+  /** Sighted-only weekday context above the grid (aria-hidden in the template). */
+  readonly weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
+
+  private readonly today = computed(() => zonedToday(this.timezone(), this.now()));
+
+  private readonly view = computed(() => {
+    const [year, month] = this.today().iso.split('-').map(Number);
+    const anchor = new Date(Date.UTC(year, month - 1 + this.monthOffset(), 1));
+    return { year: anchor.getUTCFullYear(), month: anchor.getUTCMonth() + 1 };
+  });
+
+  readonly monthLabel = computed(() =>
+    new Intl.DateTimeFormat('en-GB', { timeZone: 'UTC', month: 'long', year: 'numeric' }).format(
+      new Date(Date.UTC(this.view().year, this.view().month - 1, 1)),
+    ),
+  );
+
+  /** Open, today-or-future dates only — closed/past days never reach the DOM. */
+  readonly cells = computed(() =>
+    buildMonthGrid(this.view().year, this.view().month, this.hours(), this.today().iso),
+  );
+
+  ngAfterViewInit(): void {
+    this.heading().nativeElement.focus();
+  }
+
+  prev(): void {
+    this.monthOffset.update((offset) => Math.max(0, offset - 1));
+  }
+
+  next(): void {
+    this.monthOffset.update((offset) => offset + 1);
+  }
+
+  choose(iso: string): void {
+    this.dateSelect.emit(iso);
+  }
+
+  dayOfMonth(iso: string): number {
+    return Number(iso.slice(8, 10));
+  }
+
+  dateLabel(iso: string): string {
+    const [year, month, day] = iso.split('-').map(Number);
+    return new Intl.DateTimeFormat('en-GB', {
+      timeZone: 'UTC',
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    }).format(new Date(Date.UTC(year, month - 1, day)));
+  }
+}

--- a/src/booking/steps/party-size-step/party-size-step.component.html
+++ b/src/booking/steps/party-size-step/party-size-step.component.html
@@ -1,0 +1,29 @@
+<div class="step">
+  <button
+    type="button"
+    class="back-button"
+    data-testid="party-size-back"
+    aria-label="Back to start"
+    (click)="back.emit()"
+  >
+    <span aria-hidden="true">&larr;</span>
+  </button>
+
+  <h2 #heading tabindex="-1" class="heading">How many guests?</h2>
+  <p class="subheading">Select your party size</p>
+
+  <div class="grid" role="group" aria-label="Party size">
+    @for (size of sizes; track size) {
+      <button
+        type="button"
+        class="size-btn"
+        [class.selected]="selected() === size"
+        [attr.aria-pressed]="selected() === size"
+        [attr.data-testid]="'party-size-option-' + size"
+        (click)="choose(size)"
+      >
+        {{ size }}
+      </button>
+    }
+  </div>
+</div>

--- a/src/booking/steps/party-size-step/party-size-step.component.scss
+++ b/src/booking/steps/party-size-step/party-size-step.component.scss
@@ -1,0 +1,88 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+.step {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  text-align: left;
+}
+
+.back-button {
+  align-self: flex-start;
+  width: 44px;
+  height: 44px;
+  margin: -8px 0 8px -12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+
+  &:hover {
+    background: #f5f0eb;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--osef-brand-secondary, #8fa67a);
+    outline-offset: 2px;
+  }
+}
+
+.heading {
+  margin: 0 0 4px;
+  font-size: 1.25rem;
+  font-weight: 700;
+  outline: none;
+}
+
+.subheading {
+  margin: 0 0 24px;
+  font-size: 0.875rem;
+  color: #6b6b6b;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.size-btn {
+  width: 100%;
+  min-width: 44px;
+  min-height: 44px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  border: 2px solid #e5e0db;
+  background: #ffffff;
+  color: inherit;
+  font-family: inherit;
+  font-size: 1.125rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover:not(.selected) {
+    border-color: #6b6b6b;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--osef-brand-secondary, #8fa67a);
+    outline-offset: 2px;
+  }
+
+  &.selected {
+    background: var(--osef-brand-primary, #1a1a1a);
+    border-color: var(--osef-brand-primary, #1a1a1a);
+    color: #ffffff;
+  }
+}

--- a/src/booking/steps/party-size-step/party-size-step.component.spec.ts
+++ b/src/booking/steps/party-size-step/party-size-step.component.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PartySizeStepComponent } from './party-size-step.component';
+
+describe('PartySizeStepComponent', () => {
+  let fixture: ComponentFixture<PartySizeStepComponent>;
+
+  function queryEl(): HTMLElement {
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  async function createComponent(selected: number | null = null): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [PartySizeStepComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PartySizeStepComponent);
+    fixture.componentRef.setInput('selected', selected);
+    fixture.detectChanges();
+  }
+
+  describe('HAPPY_PATH', () => {
+    it('[P0] should render the heading and a grid of eight circular options 1–8', async () => {
+      await createComponent();
+
+      const el = fixture.nativeElement as HTMLElement;
+      expect(el.querySelector('h2')?.textContent).toContain('How many guests?');
+
+      for (const size of [1, 2, 3, 4, 5, 6, 7, 8]) {
+        expect(el.querySelector(`[data-testid="party-size-option-${size}"]`)).toBeTruthy();
+      }
+      expect(el.querySelectorAll('.size-btn')).toHaveLength(8);
+    });
+
+    it('[P0] should emit the chosen size when an option is tapped', async () => {
+      await createComponent();
+
+      const emitted: number[] = [];
+      fixture.componentInstance.partySizeSelect.subscribe((size) => emitted.push(size));
+
+      const button = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="party-size-option-4"]',
+      )!;
+      button.click();
+      fixture.detectChanges();
+
+      expect(emitted).toEqual([4]);
+    });
+  });
+
+  describe('SELECTION_STATE', () => {
+    it('[P0] should highlight only the selected option with aria-pressed', async () => {
+      await createComponent(3);
+
+      const selected = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="party-size-option-3"]',
+      )!;
+      const unselected = queryEl().querySelector<HTMLButtonElement>(
+        '[data-testid="party-size-option-5"]',
+      )!;
+
+      expect(selected.classList.contains('selected')).toBe(true);
+      expect(selected.getAttribute('aria-pressed')).toBe('true');
+      expect(unselected.classList.contains('selected')).toBe(false);
+      expect(unselected.getAttribute('aria-pressed')).toBe('false');
+    });
+  });
+
+  describe('BACK_NAVIGATION', () => {
+    it('[P1] should emit back when the back button is tapped', async () => {
+      await createComponent();
+
+      let backCount = 0;
+      fixture.componentInstance.back.subscribe(() => backCount++);
+
+      queryEl().querySelector<HTMLButtonElement>('[data-testid="party-size-back"]')!.click();
+      fixture.detectChanges();
+
+      expect(backCount).toBe(1);
+    });
+  });
+
+  describe('FOCUS_MANAGEMENT', () => {
+    it('[P0] should move focus to the step heading on init', async () => {
+      await createComponent();
+
+      const heading = queryEl().querySelector<HTMLHeadingElement>('h2')!;
+      expect(document.activeElement).toBe(heading);
+      expect(heading.getAttribute('tabindex')).toBe('-1');
+    });
+  });
+});

--- a/src/booking/steps/party-size-step/party-size-step.component.ts
+++ b/src/booking/steps/party-size-step/party-size-step.component.ts
@@ -1,0 +1,33 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+
+@Component({
+  selector: 'osef-party-size-step',
+  templateUrl: './party-size-step.component.html',
+  styleUrl: './party-size-step.component.scss',
+})
+export class PartySizeStepComponent implements AfterViewInit {
+  /** Currently chosen size, highlighted when returning via back navigation. */
+  readonly selected = input<number | null>(null);
+
+  readonly partySizeSelect = output<number>();
+  readonly back = output<void>();
+
+  private readonly heading = viewChild.required<ElementRef<HTMLHeadingElement>>('heading');
+
+  readonly sizes = [1, 2, 3, 4, 5, 6, 7, 8] as const;
+
+  ngAfterViewInit(): void {
+    this.heading().nativeElement.focus();
+  }
+
+  choose(size: number): void {
+    this.partySizeSelect.emit(size);
+  }
+}

--- a/src/booking/utils/calendar.spec.ts
+++ b/src/booking/utils/calendar.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMonthGrid,
+  isoDayNumberOf,
+  isOpenOn,
+  zonedToday,
+} from './calendar';
+import type { OpeningHours } from '../../shared/types/restaurant';
+
+/** Mon, Tue, Wed open; Thu–Sun closed. */
+const HOURS_MON_WED: OpeningHours = {
+  1: { open: '09:00', close: '17:00' },
+  2: { open: '09:00', close: '17:00' },
+  3: { open: '09:00', close: '17:00' },
+};
+
+/** Every day open. */
+const HOURS_ALL_WEEK: OpeningHours = {
+  1: { open: '09:00', close: '17:00' },
+  2: { open: '09:00', close: '17:00' },
+  3: { open: '09:00', close: '17:00' },
+  4: { open: '09:00', close: '17:00' },
+  5: { open: '09:00', close: '17:00' },
+  6: { open: '09:00', close: '17:00' },
+  7: { open: '09:00', close: '17:00' },
+};
+
+describe('zonedToday', () => {
+  it('[P0] should derive the ISO date and day number in the restaurant timezone', () => {
+    // 2026-08-20T23:30Z is already Friday Aug 21 in London (BST) but still Thursday Aug 20 in New York.
+    const now = new Date('2026-08-20T23:30:00Z');
+
+    expect(zonedToday('Europe/London', now)).toEqual({ iso: '2026-08-21', dayNumber: 5 });
+    expect(zonedToday('America/New_York', now)).toEqual({ iso: '2026-08-20', dayNumber: 4 });
+  });
+
+  it('[P1] should map each weekday to its ISO day number (1=Mon..7=Sun)', () => {
+    const expectations: [string, string][] = [
+      ['2026-08-17', '1'], // Monday
+      ['2026-08-18', '2'],
+      ['2026-08-19', '3'],
+      ['2026-08-20', '4'],
+      ['2026-08-21', '5'],
+      ['2026-08-22', '6'],
+      ['2026-08-23', '7'], // Sunday
+    ];
+
+    for (const [iso, dayNumber] of expectations) {
+      expect(isoDayNumberOf(iso)).toBe(Number(dayNumber));
+    }
+  });
+
+  it('TZ_BOUNDARY: should not depend on the device-local timezone for the date boundary', () => {
+    // One minute before London midnight vs one minute after — the ISO date must flip on the zoned boundary.
+    const beforeMidnight = new Date('2026-08-20T22:59:00Z');
+    const afterMidnight = new Date('2026-08-20T23:01:00Z');
+
+    expect(zonedToday('Europe/London', beforeMidnight).iso).toBe('2026-08-20');
+    expect(zonedToday('Europe/London', afterMidnight).iso).toBe('2026-08-21');
+  });
+
+  it('TZ_BOUNDARY: should fall back to UTC-derived date parts when the timezone is invalid', () => {
+    // Corrupt restaurant data must not crash the date step; UTC parts, never device-local getters.
+    const now = new Date('2026-08-20T23:30:00Z');
+
+    expect(zonedToday('Not/ARealZone', now)).toEqual({ iso: '2026-08-20', dayNumber: 4 });
+    expect(zonedToday('', now)).toEqual({ iso: '2026-08-20', dayNumber: 4 });
+  });
+});
+
+describe('isOpenOn', () => {
+  it('[P0] should return true when the weekday has hours and false when the key is missing', () => {
+    expect(isOpenOn(HOURS_MON_WED, '2026-08-17')).toBe(true); // Monday
+    expect(isOpenOn(HOURS_MON_WED, '2026-08-22')).toBe(false); // Saturday
+    expect(isOpenOn(HOURS_MON_WED, '2026-08-23')).toBe(false); // Sunday
+  });
+
+  it('[P0] should treat an empty hours record as always closed', () => {
+    expect(isOpenOn({}, '2026-08-17')).toBe(false);
+  });
+});
+
+describe('buildMonthGrid', () => {
+  it('[P0] should return only open dates from today onward as selectable cells', () => {
+    // August 2026: Aug 1 is a Saturday; Mon–Wed are open.
+    const cells = buildMonthGrid(2026, 8, HOURS_MON_WED, '2026-08-05');
+
+    expect(cells.map((c) => c.iso)).toEqual([
+      '2026-08-05',
+      '2026-08-10',
+      '2026-08-11',
+      '2026-08-12',
+      '2026-08-17',
+      '2026-08-18',
+      '2026-08-19',
+      '2026-08-24',
+      '2026-08-25',
+      '2026-08-26',
+      '2026-08-31',
+    ]);
+    expect(cells.every((c) => c.selectable)).toBe(true);
+    expect(cells.every((c) => c.dayNumber >= 1 && c.dayNumber <= 3)).toBe(true);
+  });
+
+  it('DAY_HIDDEN: should omit past-but-open days entirely', () => {
+    const cells = buildMonthGrid(2026, 8, HOURS_ALL_WEEK, '2026-08-20');
+
+    expect(cells[0]?.iso).toBe('2026-08-20');
+    expect(cells.some((c) => c.iso < '2026-08-20')).toBe(false);
+  });
+
+  it('DAY_HIDDEN: should include today itself when open', () => {
+    const cells = buildMonthGrid(2026, 8, HOURS_ALL_WEEK, '2026-08-21');
+
+    expect(cells.map((c) => c.iso)).toContain('2026-08-21');
+  });
+
+  it('MONTH_NAV: should handle a month with zero selectable days by returning an empty grid', () => {
+    const cells = buildMonthGrid(2026, 2, {}, '2026-01-01');
+
+    expect(cells).toEqual([]);
+  });
+
+  it('[P1] should compute the correct number of days for 31-day months and February', () => {
+    const january = buildMonthGrid(2026, 1, HOURS_ALL_WEEK, '2026-01-01');
+    const february2028 = buildMonthGrid(2028, 2, HOURS_ALL_WEEK, '2028-02-01'); // leap year
+
+    expect(january).toHaveLength(31);
+    expect(february2028).toHaveLength(29);
+    expect(january.at(-1)?.iso).toBe('2026-01-31');
+    expect(february2028.at(-1)?.iso).toBe('2028-02-29');
+  });
+});

--- a/src/booking/utils/calendar.spec.ts
+++ b/src/booking/utils/calendar.spec.ts
@@ -25,7 +25,7 @@ const HOURS_ALL_WEEK: OpeningHours = {
   7: { open: '09:00', close: '17:00' },
 };
 
-describe('zonedToday', () => {
+describe('HAPPY_PATH', () => {
   it('[P0] should derive the ISO date and day number in the restaurant timezone', () => {
     // 2026-08-20T23:30Z is already Friday Aug 21 in London (BST) but still Thursday Aug 20 in New York.
     const now = new Date('2026-08-20T23:30:00Z');
@@ -50,56 +50,12 @@ describe('zonedToday', () => {
     }
   });
 
-  it('TZ_BOUNDARY: should not depend on the device-local timezone for the date boundary', () => {
-    // One minute before London midnight vs one minute after — the ISO date must flip on the zoned boundary.
-    const beforeMidnight = new Date('2026-08-20T22:59:00Z');
-    const afterMidnight = new Date('2026-08-20T23:01:00Z');
-
-    expect(zonedToday('Europe/London', beforeMidnight).iso).toBe('2026-08-20');
-    expect(zonedToday('Europe/London', afterMidnight).iso).toBe('2026-08-21');
-  });
-
-  it('TZ_BOUNDARY: should fall back to UTC-derived date parts when the timezone is invalid', () => {
-    // Corrupt restaurant data must not crash the date step; UTC parts, never device-local getters.
-    const now = new Date('2026-08-20T23:30:00Z');
-
-    expect(zonedToday('Not/ARealZone', now)).toEqual({ iso: '2026-08-20', dayNumber: 4 });
-    expect(zonedToday('', now)).toEqual({ iso: '2026-08-20', dayNumber: 4 });
-  });
-
-  it('[P1] should coerce a missing or NaN clock to the epoch instead of throwing', () => {
-    // A broken injected clock must degrade to epoch-derived parts, never RangeError.
-    const broken = new Date('not-a-date');
-    expect(Number.isNaN(broken.getTime())).toBe(true);
-
-    expect(zonedToday('Europe/London', broken)).toEqual({ iso: '1970-01-01', dayNumber: 4 });
-    expect(zonedToday('Not/ARealZone', broken)).toEqual({ iso: '1970-01-01', dayNumber: 4 });
-    expect(zonedToday('Europe/London', undefined as unknown as Date)).toEqual({
-      iso: '1970-01-01',
-      dayNumber: 4,
-    });
-  });
-
-  it('[P1] should resolve dates across the New Year boundary', () => {
-    // 2026-12-31T23:59Z is still Dec 31 in London; one minute later it is Jan 1, 2027.
-    expect(zonedToday('Europe/London', new Date('2026-12-31T23:59:00Z')).iso).toBe('2026-12-31');
-    expect(zonedToday('Europe/London', new Date('2027-01-01T00:01:00Z')).iso).toBe('2027-01-01');
-  });
-});
-
-describe('isOpenOn', () => {
-  it('[P0] should return true when the weekday has hours and false when the key is missing', () => {
+  it('[P0] should treat a weekday as open only when its DayNumber key has hours', () => {
     expect(isOpenOn(HOURS_MON_WED, '2026-08-17')).toBe(true); // Monday
     expect(isOpenOn(HOURS_MON_WED, '2026-08-22')).toBe(false); // Saturday
     expect(isOpenOn(HOURS_MON_WED, '2026-08-23')).toBe(false); // Sunday
   });
 
-  it('[P0] should treat an empty hours record as always closed', () => {
-    expect(isOpenOn({}, '2026-08-17')).toBe(false);
-  });
-});
-
-describe('buildMonthGrid', () => {
   it('[P0] should return only open dates from today onward as selectable cells', () => {
     // August 2026: Aug 1 is a Saturday; Mon–Wed are open.
     const cells = buildMonthGrid(2026, 8, HOURS_MON_WED, '2026-08-05');
@@ -120,36 +76,49 @@ describe('buildMonthGrid', () => {
     expect(cells.every((c) => c.selectable)).toBe(true);
     expect(cells.every((c) => c.dayNumber >= 1 && c.dayNumber <= 3)).toBe(true);
   });
+});
 
-  it('DAY_HIDDEN: should omit past-but-open days entirely', () => {
-    const cells = buildMonthGrid(2026, 8, HOURS_ALL_WEEK, '2026-08-20');
+describe('TZ_BOUNDARY', () => {
+  it('[P0] should not depend on the device-local timezone for the date boundary', () => {
+    // One minute before London midnight vs one minute after — the ISO date must flip on the zoned boundary.
+    const beforeMidnight = new Date('2026-08-20T22:59:00Z');
+    const afterMidnight = new Date('2026-08-20T23:01:00Z');
 
-    expect(cells[0]?.iso).toBe('2026-08-20');
-    expect(cells.some((c) => c.iso < '2026-08-20')).toBe(false);
+    expect(zonedToday('Europe/London', beforeMidnight).iso).toBe('2026-08-20');
+    expect(zonedToday('Europe/London', afterMidnight).iso).toBe('2026-08-21');
   });
 
-  it('DAY_HIDDEN: should include today itself when open', () => {
-    const cells = buildMonthGrid(2026, 8, HOURS_ALL_WEEK, '2026-08-21');
+  it('[P1] should fall back to UTC-derived date parts when the timezone is invalid', () => {
+    // Corrupt restaurant data must not crash the date step; UTC parts, never device-local getters.
+    const now = new Date('2026-08-20T23:30:00Z');
 
-    expect(cells.map((c) => c.iso)).toContain('2026-08-21');
+    expect(zonedToday('Not/ARealZone', now)).toEqual({ iso: '2026-08-20', dayNumber: 4 });
+    expect(zonedToday('', now)).toEqual({ iso: '2026-08-20', dayNumber: 4 });
   });
 
-  it('MONTH_NAV: should handle a month with zero selectable days by returning an empty grid', () => {
-    const cells = buildMonthGrid(2026, 2, {}, '2026-01-01');
+  it('[P1] should resolve dates across the New Year boundary', () => {
+    // 2026-12-31T23:59Z is still Dec 31 in London; one minute later it is Jan 1, 2027.
+    expect(zonedToday('Europe/London', new Date('2026-12-31T23:59:00Z')).iso).toBe('2026-12-31');
+    expect(zonedToday('Europe/London', new Date('2027-01-01T00:01:00Z')).iso).toBe('2027-01-01');
+  });
+});
 
-    expect(cells).toEqual([]);
+describe('EDGE_CASE', () => {
+  it('[P1] should coerce a missing or NaN clock to the epoch instead of throwing', () => {
+    // A broken injected clock must degrade to epoch-derived parts, never RangeError.
+    const broken = new Date('not-a-date');
+    expect(Number.isNaN(broken.getTime())).toBe(true);
+
+    expect(zonedToday('Europe/London', broken)).toEqual({ iso: '1970-01-01', dayNumber: 4 });
+    expect(zonedToday('Not/ARealZone', broken)).toEqual({ iso: '1970-01-01', dayNumber: 4 });
+    expect(zonedToday('Europe/London', undefined as unknown as Date)).toEqual({
+      iso: '1970-01-01',
+      dayNumber: 4,
+    });
   });
 
-  it('[P1] MONTH_NAV: should handle the December-to-January year boundary', () => {
-    // December tail from the pinned clock, then the full January grid.
-    const december = buildMonthGrid(2026, 12, HOURS_ALL_WEEK, '2026-12-28');
-    expect(december.map((c) => c.iso)).toEqual(['2026-12-28', '2026-12-29', '2026-12-30', '2026-12-31']);
-
-    const january = buildMonthGrid(2027, 1, HOURS_ALL_WEEK, '2026-12-28');
-    expect(january[0]?.iso).toBe('2027-01-01');
-    expect(january[0]?.dayNumber).toBe(5); // Jan 1 2027 is a Friday
-    expect(january.at(-1)?.iso).toBe('2027-01-31');
-    expect(january.every((c) => c.iso.startsWith('2027-01-'))).toBe(true);
+  it('[P0] should treat an empty hours record as always closed', () => {
+    expect(isOpenOn({}, '2026-08-17')).toBe(false);
   });
 
   it('[P1] should compute the correct number of days for 31-day months and February', () => {
@@ -160,5 +129,40 @@ describe('buildMonthGrid', () => {
     expect(february2028).toHaveLength(29);
     expect(january.at(-1)?.iso).toBe('2026-01-31');
     expect(february2028.at(-1)?.iso).toBe('2028-02-29');
+  });
+});
+
+describe('DAY_HIDDEN', () => {
+  it('[P0] should omit past-but-open days entirely', () => {
+    const cells = buildMonthGrid(2026, 8, HOURS_ALL_WEEK, '2026-08-20');
+
+    expect(cells[0]?.iso).toBe('2026-08-20');
+    expect(cells.some((c) => c.iso < '2026-08-20')).toBe(false);
+  });
+
+  it('[P0] should include today itself when open', () => {
+    const cells = buildMonthGrid(2026, 8, HOURS_ALL_WEEK, '2026-08-21');
+
+    expect(cells.map((c) => c.iso)).toContain('2026-08-21');
+  });
+});
+
+describe('MONTH_NAV', () => {
+  it('[P1] should handle a month with zero selectable days by returning an empty grid', () => {
+    const cells = buildMonthGrid(2026, 2, {}, '2026-01-01');
+
+    expect(cells).toEqual([]);
+  });
+
+  it('[P1] should handle the December-to-January year boundary', () => {
+    // December tail from the pinned clock, then the full January grid.
+    const december = buildMonthGrid(2026, 12, HOURS_ALL_WEEK, '2026-12-28');
+    expect(december.map((c) => c.iso)).toEqual(['2026-12-28', '2026-12-29', '2026-12-30', '2026-12-31']);
+
+    const january = buildMonthGrid(2027, 1, HOURS_ALL_WEEK, '2026-12-28');
+    expect(january[0]?.iso).toBe('2027-01-01');
+    expect(january[0]?.dayNumber).toBe(5); // Jan 1 2027 is a Friday
+    expect(january.at(-1)?.iso).toBe('2027-01-31');
+    expect(january.every((c) => c.iso.startsWith('2027-01-'))).toBe(true);
   });
 });

--- a/src/booking/utils/calendar.spec.ts
+++ b/src/booking/utils/calendar.spec.ts
@@ -66,6 +66,25 @@ describe('zonedToday', () => {
     expect(zonedToday('Not/ARealZone', now)).toEqual({ iso: '2026-08-20', dayNumber: 4 });
     expect(zonedToday('', now)).toEqual({ iso: '2026-08-20', dayNumber: 4 });
   });
+
+  it('[P1] should coerce a missing or NaN clock to the epoch instead of throwing', () => {
+    // A broken injected clock must degrade to epoch-derived parts, never RangeError.
+    const broken = new Date('not-a-date');
+    expect(Number.isNaN(broken.getTime())).toBe(true);
+
+    expect(zonedToday('Europe/London', broken)).toEqual({ iso: '1970-01-01', dayNumber: 4 });
+    expect(zonedToday('Not/ARealZone', broken)).toEqual({ iso: '1970-01-01', dayNumber: 4 });
+    expect(zonedToday('Europe/London', undefined as unknown as Date)).toEqual({
+      iso: '1970-01-01',
+      dayNumber: 4,
+    });
+  });
+
+  it('[P1] should resolve dates across the New Year boundary', () => {
+    // 2026-12-31T23:59Z is still Dec 31 in London; one minute later it is Jan 1, 2027.
+    expect(zonedToday('Europe/London', new Date('2026-12-31T23:59:00Z')).iso).toBe('2026-12-31');
+    expect(zonedToday('Europe/London', new Date('2027-01-01T00:01:00Z')).iso).toBe('2027-01-01');
+  });
 });
 
 describe('isOpenOn', () => {
@@ -119,6 +138,18 @@ describe('buildMonthGrid', () => {
     const cells = buildMonthGrid(2026, 2, {}, '2026-01-01');
 
     expect(cells).toEqual([]);
+  });
+
+  it('[P1] MONTH_NAV: should handle the December-to-January year boundary', () => {
+    // December tail from the pinned clock, then the full January grid.
+    const december = buildMonthGrid(2026, 12, HOURS_ALL_WEEK, '2026-12-28');
+    expect(december.map((c) => c.iso)).toEqual(['2026-12-28', '2026-12-29', '2026-12-30', '2026-12-31']);
+
+    const january = buildMonthGrid(2027, 1, HOURS_ALL_WEEK, '2026-12-28');
+    expect(january[0]?.iso).toBe('2027-01-01');
+    expect(january[0]?.dayNumber).toBe(5); // Jan 1 2027 is a Friday
+    expect(january.at(-1)?.iso).toBe('2027-01-31');
+    expect(january.every((c) => c.iso.startsWith('2027-01-'))).toBe(true);
   });
 
   it('[P1] should compute the correct number of days for 31-day months and February', () => {

--- a/src/booking/utils/calendar.ts
+++ b/src/booking/utils/calendar.ts
@@ -1,0 +1,80 @@
+import type { DayNumber, OpeningHours } from '../../shared/types/restaurant';
+
+export interface ZonedToday {
+  /** Calendar date in the target timezone, formatted as YYYY-MM-DD. */
+  iso: string;
+  /** ISO day number of that date: 1=Monday .. 7=Sunday. */
+  dayNumber: DayNumber;
+}
+
+export interface CalendarCell {
+  /** Calendar date formatted as YYYY-MM-DD. */
+  iso: string;
+  /** ISO day number of the date: 1=Monday .. 7=Sunday. */
+  dayNumber: DayNumber;
+  /** Always true — closed and past days are omitted from the grid entirely. */
+  selectable: boolean;
+}
+
+/** Parses a YYYY-MM-DD string into its UTC date parts. */
+function parseIso(iso: string): { year: number; month: number; day: number } {
+  const [year, month, day] = iso.split('-').map(Number);
+  return { year, month, day };
+}
+
+/** Derives the ISO day number (1=Mon..7=Sun) from a YYYY-MM-DD string via a UTC-constructed date. */
+export function isoDayNumberOf(iso: string): DayNumber {
+  const { year, month, day } = parseIso(iso);
+  const utcDayOfWeek = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+  return (((utcDayOfWeek + 6) % 7) + 1) as DayNumber;
+}
+
+/**
+ * Resolves "today" in the restaurant's IANA timezone (never device-local getters).
+ * `now` must be injected by the caller. An invalid/unsupported timezone falls
+ * back to UTC-derived date parts instead of throwing on corrupt restaurant data.
+ */
+export function zonedToday(timezone: string, now: Date): ZonedToday {
+  try {
+    const iso = new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(now);
+    return { iso, dayNumber: isoDayNumberOf(iso) };
+  } catch {
+    const iso = now.toISOString().slice(0, 10);
+    return { iso, dayNumber: isoDayNumberOf(iso) };
+  }
+}
+
+/** A date is open when its weekday has an entry in `hours` (missing key = closed). */
+export function isOpenOn(hours: OpeningHours, iso: string): boolean {
+  return hours[isoDayNumberOf(iso)] !== undefined;
+}
+
+/**
+ * Builds the selectable cells for one month (month is 1-based: January = 1).
+ * Only open AND today-or-future dates (compared against `todayIso`) are returned;
+ * closed and past days are omitted entirely so they never reach the DOM.
+ */
+export function buildMonthGrid(
+  year: number,
+  month: number,
+  hours: OpeningHours,
+  todayIso: string,
+): CalendarCell[] {
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const mm = String(month).padStart(2, '0');
+  const cells: CalendarCell[] = [];
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    const iso = `${year}-${mm}-${String(day).padStart(2, '0')}`;
+    if (iso < todayIso) continue;
+    if (!isOpenOn(hours, iso)) continue;
+    cells.push({ iso, dayNumber: isoDayNumberOf(iso), selectable: true });
+  }
+
+  return cells;
+}

--- a/src/booking/utils/calendar.ts
+++ b/src/booking/utils/calendar.ts
@@ -1,5 +1,8 @@
 import type { DayNumber, OpeningHours } from '../../shared/types/restaurant';
 
+/** Angular dev-mode flag — defined globally by the framework, absent in production builds. */
+declare const ngDevMode: boolean | object | undefined;
+
 export interface ZonedToday {
   /** Calendar date in the target timezone, formatted as YYYY-MM-DD. */
   iso: string;
@@ -32,19 +35,24 @@ export function isoDayNumberOf(iso: string): DayNumber {
 /**
  * Resolves "today" in the restaurant's IANA timezone (never device-local getters).
  * `now` must be injected by the caller. An invalid/unsupported timezone falls
- * back to UTC-derived date parts instead of throwing on corrupt restaurant data.
+ * back to UTC-derived date parts instead of throwing on corrupt restaurant data
+ * (with a dev-mode warning); a missing/NaN clock falls back to the epoch.
  */
 export function zonedToday(timezone: string, now: Date): ZonedToday {
+  const safeNow = now instanceof Date && !Number.isNaN(now.getTime()) ? now : new Date(0);
   try {
     const iso = new Intl.DateTimeFormat('en-CA', {
       timeZone: timezone,
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
-    }).format(now);
+    }).format(safeNow);
     return { iso, dayNumber: isoDayNumberOf(iso) };
   } catch {
-    const iso = now.toISOString().slice(0, 10);
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      console.warn(`[osef] zonedToday: invalid timezone "${timezone}" — falling back to UTC.`);
+    }
+    const iso = safeNow.toISOString().slice(0, 10);
     return { iso, dayNumber: isoDayNumberOf(iso) };
   }
 }

--- a/src/booking/utils/clock.ts
+++ b/src/booking/utils/clock.ts
@@ -1,0 +1,9 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * Injectable clock — the only sanctioned source of `new Date()`.
+ * Override in tests with a fixed instant for deterministic time/timezone behavior.
+ */
+export const NOW = new InjectionToken<() => Date>('osef.now', {
+  factory: () => () => new Date(),
+});


### PR DESCRIPTION
## Story 2.2: Party Size & Date Selection

Implements the party-size and date-selection steps of the public booking flow (spec: `_bmad-output/implementation-artifacts/spec-2-2-party-size-date-selection.md`).

### Commits
- `feat(2-2)` — party size & date selection steps on the public booking page
- `fix(2-2)` — hardening from post-review lens findings (review round 1)
- `review(2-2)` — adversarial 4-layer code review, all accepted patches applied (review round 2)

### Review round 2 — patches applied (11/11)
**P0**
- Calendar grid misalignment with weekday headers: leading spacers rendered for closed/past leading days (`GRID_ALIGNMENT` tests)
- Future-month selection highlight lost on back-navigation: month offset restored from the selected date (AC4)
- P0 e2e made month-end-safe via `showMonth()` navigation helper
- Vacuous closed-Saturday assertion fixed: absence asserted inside its own rendered month
- Landing announcement pinned: "Step 1 of 6: Start" on initial load and return-to-landing ([P0] test)

**P1 / decisions resolved as patches**
- Visual "today" marker (brand-secondary outline + bold) with `aria-current="date"` and tests
- Stale "today" across midnight: today re-evaluates on calendar navigation (`navTick`) + TZ_BOUNDARY test
- e2e helpers take `restaurant.timezone` from the fixture instead of hardcoding Europe/London
- Unit-test conventions: scenario-based describes + `[P0]`/`[P1]` prefixes across `calendar.spec.ts`
- Spec change-log disclosure completed; status metadata reconciled (story → done)

4 lower-value findings deferred to `deferred-work.md`.

### Verification
- `npm run lint`: clean for all changed files (remaining repo-wide warnings pre-exist on master)
- `npm test`: **240/240 passing** (26 files)